### PR TITLE
fixing conda build

### DIFF
--- a/meta.yaml
+++ b/meta.yaml
@@ -3,34 +3,29 @@ package:
   version: "2.0.0"
 
 source:
-  path: dist
-  fn: Corrfunc-2.0.0.tar.gz
-  md5: 8523662c871c33f3db44ffe535c0e286
+  fn: corrfunc-2.0.0.tar.gz
+  url: https://pypi.io/packages/source/c/corrfunc/corrfunc-2.0.0.tar.gz
+  md5: 1ef4ba2d917929aede23efddfcfbc78a
 
-  
-  # git_url: https://github.com/manodeep/Corrfunc.git
-  # git_rev: master
-  
+build:
+  number : 0
+  script :
+    - make install
+    - python setup.py install
+
 requirements:
   build:
-    - python >=2.6
-    - numpy >=1.7
-    - setuptools
+    - python
+    - numpy x.x
     - future
     - gsl
 
   run:
-    - python >=2.6
+    - python
     - future
-    - numpy >=1.7
+    - numpy x.x
     - gsl
 
-build:
-  detect_binary_files_with_prefix: True
-  script: python setup.py install --single-version-externally-managed --record record.txt
-  binary_relocation: False
-  skip: True # [win]
-  
 test:
   files:
     - theory/tests/data/gals_Mr19.ff
@@ -51,15 +46,13 @@ test:
   commands:
     - python -c "import Corrfunc.call_correlation_functions as c; c.main()"
     - python -c "import Corrfunc.call_correlation_functions_mocks as m; m.main()"
-	
+
 about:
   home: http://manodeep.github.io/Corrfunc/
   license: MIT
   license_file: LICENSE
   summary: Blazing fast correlation functions on the CPU
-  
+
 extra:
   maintainers:
     - Manodeep Sinha <manodeep@gmail.com>
-    
-    

--- a/rules.mk
+++ b/rules.mk
@@ -2,9 +2,9 @@ TARGETOBJS := $(TARGETSRC:.c=.o)
 LIBOBJS :=$(LIBSRC:.c=.o)
 
 gridlink_impl_double.o:gridlink_impl_double.c gridlink_impl_double.h
-gridlink_impl_float.o:gridlink_impl_float.c gridlink_impl_float.h 
+gridlink_impl_float.o:gridlink_impl_float.c gridlink_impl_float.h
 gridlink_mocks_impl_double.o:gridlink_mocks_impl_double.c gridlink_mocks_impl_double.h
-gridlink_mocks_impl_float.o:gridlink_mocks_impl_float.c gridlink_mocks_impl_float.h 
+gridlink_mocks_impl_float.o:gridlink_mocks_impl_float.c gridlink_mocks_impl_float.h
 gridlink_impl_double.h:cellarray_double.h
 gridlink_impl_float.h:cellarray_float.h
 cellarray_double.h:weight_functions_double.h
@@ -16,10 +16,10 @@ gridlink_mocks_impl_float.h:cellarray_mocks_float.h
 
 .SUFFIXES:
 
-$(TARGET): $(TARGETOBJS) $(ROOT_DIR)/common.mk 
+$(TARGET): $(TARGETOBJS) $(ROOT_DIR)/common.mk
 	$(CC) $(TARGETOBJS) $(C_LIBRARIES) $(CLINK) $(EXTRA_LINK) -o $@
 
-$(TARGET).o: $(TARGET).c $(ROOT_DIR)/common.mk Makefile $(ROOT_DIR)/theory.options $(ROOT_DIR)/mocks.options 
+$(TARGET).o: $(TARGET).c $(ROOT_DIR)/common.mk Makefile $(ROOT_DIR)/theory.options $(ROOT_DIR)/mocks.options
 	$(CC) $(OPT) $(CFLAGS) $(INCLUDE) $(EXTRA_INCL) -c $< -o $@
 
 %_float.c: %.c.src Makefile
@@ -53,16 +53,16 @@ $(TARGET).o: $(TARGET).c $(ROOT_DIR)/common.mk Makefile $(ROOT_DIR)/theory.optio
 %_double.o: %_double.c
 	$(CC) -DDOUBLE_PREC $(CFLAGS) $(INCLUDE) $(EXTRA_INCL) -c $< -o $@
 
-%_float.o: %_float.c 
+%_float.o: %_float.c
 	$(CC) -DNDOUBLE_PREC $(CFLAGS) $(INCLUDE) $(EXTRA_INCL) -c $< -o $@
 
 %.o: %.c $(ROOT_DIR)/common.mk Makefile
 	$(CC) $(CFLAGS) $(INCLUDE) $(EXTRA_INCL) -c $< -o $@
 
-$(LIBRARY): $(LIBOBJS) $(ROOT_DIR)/mocks.options $(ROOT_DIR)/theory.options $(ROOT_DIR)/common.mk Makefile 
+$(LIBRARY): $(LIBOBJS) $(ROOT_DIR)/mocks.options $(ROOT_DIR)/theory.options $(ROOT_DIR)/common.mk Makefile
 	ar rcs $@ $(LIBOBJS)
 
-$(INSTALL_LIB_DIR)/%.a: %.a | $(INSTALL_LIB_DIR) 
+$(INSTALL_LIB_DIR)/%.a: %.a | $(INSTALL_LIB_DIR)
 	cp -p $(LIBRARY) $(INSTALL_LIB_DIR)/
 
 $(INSTALL_HEADERS_DIR)/%.h: %.h $(INSTALL_HEADERS_DIR)/defs.h | $(INSTALL_HEADERS_DIR)
@@ -79,7 +79,7 @@ $(INSTALL_LIB_DIR) $(INSTALL_BIN_DIR) $(INSTALL_HEADERS_DIR):
 
 ifdef PROJECT
   ifeq ($(UNAME), Darwin)
-    PYTHON_LINK += -Xlinker -install_name -Xlinker "$(PROJECT)$(PYTHON_SOABI)"
+    PYTHON_LINK += -Xlinker -install_name -Xlinker "$(PROJECT)$(PYTHON_SOABI).so"
   else
     PYTHON_LINK += -Xlinker -soname -Xlinker "$(PROJECT)$(PYTHON_SOABI).so.$(MAJOR)"
   endif
@@ -93,4 +93,3 @@ endif
 celna: clean
 celan: clean
 clena: clean
-


### PR DESCRIPTION
By re-naming mac install name to include ``.so``, Corrfunc can be built on linux and Mac. The ``meta.yaml`` file will build pinned numpy versions. For ``nbodykit`` we use

```
conda build-all Corrfunc/ --matrix-max-n-minor-versions 3 --matrix-conditions "2.7*|>3.4" "numpy >=1.11*"
```
This will build for Python versions 2.7, 3.5, and 3.6 and numpy versions 1.11, 1.12, and 1.13.

A new pypi version will need to be added and the links updated for this to build properly.