### PR TITLE
Reduce gridlink memory footprint

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -15,7 +15,7 @@ New features
 
 Enhancements
 ------------
-- Reduce gridlink memory footprint [#186]
+- Reduce memory footprint of the cell pairs [#186]
 
 
 2.3.0 (2019-05-20)

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,8 +10,16 @@ New features
 - conda installable package
 - GPU version
 
-2.3.0 (upcoming)
+2.3.1 (upcoming)
 ================
+
+Enhancements
+------------
+- Reduce gridlink memory footprint [#186]
+
+
+2.3.0 (2019-05-20)
+==================
 
 **Breaking Changes**
 --------------------

--- a/Corrfunc/__init__.py
+++ b/Corrfunc/__init__.py
@@ -10,7 +10,7 @@ from __future__ import (division, print_function, absolute_import,
                         unicode_literals)
 import os
 
-__version__ = "2.3.0"
+__version__ = "2.3.1"
 __author__ = "Manodeep Sinha <manodeep@gmail.com>"
 
 

--- a/common.mk
+++ b/common.mk
@@ -41,7 +41,7 @@ OPT += -DUSE_OMP
 DISTNAME:=Corrfunc
 MAJOR:=2
 MINOR:=3
-PATCHLEVEL:=0
+PATCHLEVEL:=1
 VERSION:=$(MAJOR).$(MINOR).$(PATCHLEVEL)
 ABI_COMPAT_VERSION:=$(MAJOR).0
 # Whenever conda needs to be checked again

--- a/mocks/DDrppi_mocks/countpairs_rp_pi_mocks_impl.c.src
+++ b/mocks/DDrppi_mocks/countpairs_rp_pi_mocks_impl.c.src
@@ -625,10 +625,13 @@ int countpairs_mocks_DOUBLE(const int64_t ND1, DOUBLE *ra1, DOUBLE *dec1, DOUBLE
                 DOUBLE *this_rpavg = options->need_avg_sep ? rpavg:NULL;
                 DOUBLE *this_weightavg = need_weightavg ? weightavg:NULL;
 
-                const int status = countpairs_rp_pi_mocks_function_DOUBLE(this_cell_pair->N1, this_cell_pair->x1,
-                                                                          this_cell_pair->y1, this_cell_pair->z1, this_cell_pair->weights1,
-                                                                          this_cell_pair->N2, this_cell_pair->x2,
-                                                                          this_cell_pair->y2, this_cell_pair->z2, this_cell_pair->weights2,
+                const int64_t icell = this_cell_pair->cellindex1;
+                const int64_t icell2 = this_cell_pair->cellindex2;
+                const cellarray_mocks_DOUBLE *first = &lattice1[icell];
+                const cellarray_mocks_DOUBLE *second = &lattice2[icell2];
+
+                const int status = countpairs_rp_pi_mocks_function_DOUBLE(first->nelements, first->x, first->y, first->z, &(first->weights),
+                                                                          second->nelements, second->x, second->y, second->z, &(second->weights),
                                                                           this_cell_pair->same_cell,
                                                                           options->fast_divide_and_NR_steps,
                                                                           sqr_rpmax, sqr_rpmin, nrpbin, npibin, rupp_sqr, pimax,

--- a/mocks/DDsmu_mocks/countpairs_s_mu_mocks_impl.c.src
+++ b/mocks/DDsmu_mocks/countpairs_s_mu_mocks_impl.c.src
@@ -631,10 +631,13 @@ int countpairs_mocks_s_mu_DOUBLE(const int64_t ND1, DOUBLE *ra1, DOUBLE *dec1, D
                 DOUBLE *this_savg = options->need_avg_sep ? &(savg[0]):NULL;
                 DOUBLE *this_weightavg = need_weightavg ? weightavg:NULL;
 
-                const int status = countpairs_s_mu_mocks_function_DOUBLE(this_cell_pair->N1, this_cell_pair->x1,
-                                                                         this_cell_pair->y1, this_cell_pair->z1, this_cell_pair->weights1,
-                                                                         this_cell_pair->N2, this_cell_pair->x2,
-                                                                         this_cell_pair->y2, this_cell_pair->z2, this_cell_pair->weights2,
+                const int64_t icell = this_cell_pair->cellindex1;
+                const int64_t icell2 = this_cell_pair->cellindex2;
+                const cellarray_mocks_DOUBLE *first = &lattice1[icell];
+                const cellarray_mocks_DOUBLE *second = &lattice2[icell2];
+
+                const int status = countpairs_s_mu_mocks_function_DOUBLE(first->nelements, first->x, first->y, first->z, &(first->weights),
+                                                                         second->nelements, second->x, second->y, second->z, &(second->weights),
                                                                          this_cell_pair->same_cell,
                                                                          options->fast_divide_and_NR_steps,
                                                                          sqr_smax, sqr_smin, nsbin, nmu_bins, supp_sqr, mu_max,

--- a/mocks/DDtheta_mocks/countpairs_theta_mocks_impl.c.src
+++ b/mocks/DDtheta_mocks/countpairs_theta_mocks_impl.c.src
@@ -1007,10 +1007,13 @@ int countpairs_theta_mocks_DOUBLE(const int64_t ND1, DOUBLE *ra1, DOUBLE *dec1,
                 DOUBLE *this_thetaavg = options->need_avg_sep ? thetaavg:NULL;
                 DOUBLE *this_weightavg = need_weightavg ? weightavg:NULL;
 
-                const int status = countpairs_theta_mocks_function_DOUBLE(this_cell_pair->N1, this_cell_pair->x1,
-                                                                          this_cell_pair->y1, this_cell_pair->z1, this_cell_pair->weights1,
-                                                                          this_cell_pair->N2, this_cell_pair->x2,
-                                                                          this_cell_pair->y2, this_cell_pair->z2, this_cell_pair->weights2,
+                const int64_t icell = this_cell_pair->cellindex1;
+                const int64_t icell2 = this_cell_pair->cellindex2;
+                const cellarray_mocks_DOUBLE *first = &lattice1[icell];
+                const cellarray_mocks_DOUBLE *second = &lattice2[icell2];
+
+                const int status = countpairs_theta_mocks_function_DOUBLE(first->nelements, first->x, first->y, first->z, &(first->weights),
+                                                                          second->nelements, second->x, second->y, second->z, &(second->weights),
                                                                           this_cell_pair->same_cell,
                                                                           options->fast_acos,
                                                                           costhetamax, costhetamin, nthetabin,

--- a/theory/DD/countpairs_impl.c.src
+++ b/theory/DD/countpairs_impl.c.src
@@ -452,10 +452,13 @@ int countpairs_DOUBLE(const int64_t ND1, DOUBLE *X1, DOUBLE *Y1, DOUBLE *Z1,
                 DOUBLE *this_rpavg = options->need_avg_sep ? rpavg:NULL;
                 DOUBLE *this_weightavg = need_weightavg ? weightavg:NULL;
 
-                const int status = countpairs_function_DOUBLE(this_cell_pair->N1, this_cell_pair->x1,
-                                                              this_cell_pair->y1, this_cell_pair->z1, this_cell_pair->weights1,
-                                                              this_cell_pair->N2, this_cell_pair->x2,
-                                                              this_cell_pair->y2, this_cell_pair->z2, this_cell_pair->weights2,
+                const int64_t icell = this_cell_pair->cellindex1;
+                const int64_t icell2 = this_cell_pair->cellindex2;
+                const cellarray_DOUBLE *first = &lattice1[icell];
+                const cellarray_DOUBLE *second = &lattice2[icell2];
+
+                const int status = countpairs_function_DOUBLE(first->nelements, first->x, first->y, first->z, &(first->weights),
+                                                              second->nelements, second->x, second->y, second->z, &(second->weights),
                                                               this_cell_pair->same_cell,
                                                               sqr_rpmax, sqr_rpmin, nrpbin, rupp_sqr, pimax, //pimax is simply rpmax cast to DOUBLE
                                                               this_cell_pair->xwrap, this_cell_pair->ywrap, this_cell_pair->zwrap,

--- a/theory/DDrppi/countpairs_rp_pi_impl.c.src
+++ b/theory/DDrppi/countpairs_rp_pi_impl.c.src
@@ -446,10 +446,13 @@ int countpairs_rp_pi_DOUBLE(const int64_t ND1, DOUBLE *X1, DOUBLE *Y1, DOUBLE *Z
                 DOUBLE *this_rpavg = options->need_avg_sep ? rpavg:NULL;
                 DOUBLE *this_weightavg = need_weightavg ? weightavg:NULL;
 
-                const int status = countpairs_rp_pi_function_DOUBLE(this_cell_pair->N1, this_cell_pair->x1,
-                                                                    this_cell_pair->y1, this_cell_pair->z1, this_cell_pair->weights1,
-                                                                    this_cell_pair->N2, this_cell_pair->x2,
-                                                                    this_cell_pair->y2, this_cell_pair->z2, this_cell_pair->weights2,
+                const int64_t icell = this_cell_pair->cellindex1;
+                const int64_t icell2 = this_cell_pair->cellindex2;
+                const cellarray_DOUBLE *first = &lattice1[icell];
+                const cellarray_DOUBLE *second = &lattice2[icell2];
+
+                const int status = countpairs_rp_pi_function_DOUBLE(first->nelements, first->x, first->y, first->z, &(first->weights),
+                                                                    second->nelements, second->x, second->y, second->z, &(second->weights),
                                                                     this_cell_pair->same_cell,
                                                                     sqr_rpmax, sqr_rpmin, nrpbin, npibin, rupp_sqr, pimax,
                                                                     this_cell_pair->xwrap, this_cell_pair->ywrap, this_cell_pair->zwrap,

--- a/theory/DDsmu/countpairs_s_mu_impl.c.src
+++ b/theory/DDsmu/countpairs_s_mu_impl.c.src
@@ -466,10 +466,13 @@ int countpairs_s_mu_DOUBLE(const int64_t ND1, DOUBLE *X1, DOUBLE *Y1, DOUBLE *Z1
                 DOUBLE *this_rpavg = options->need_avg_sep ? savg:NULL;
                 DOUBLE *this_weightavg = need_weightavg ? weightavg:NULL;
 
-                const int status = countpairs_s_mu_function_DOUBLE(this_cell_pair->N1, this_cell_pair->x1,
-                                                                   this_cell_pair->y1, this_cell_pair->z1, this_cell_pair->weights1,
-                                                                   this_cell_pair->N2, this_cell_pair->x2,
-                                                                   this_cell_pair->y2, this_cell_pair->z2, this_cell_pair->weights2,
+                const int64_t icell = this_cell_pair->cellindex1;
+                const int64_t icell2 = this_cell_pair->cellindex2;
+                const cellarray_DOUBLE *first = &lattice1[icell];
+                const cellarray_DOUBLE *second = &lattice2[icell2];
+
+                const int status = countpairs_s_mu_function_DOUBLE(first->nelements, first->x, first->y, first->z, &(first->weights),
+                                                                   second->nelements, second->x, second->y, second->z, &(second->weights),
                                                                    this_cell_pair->same_cell,
                                                                    options->fast_divide_and_NR_steps,
                                                                    sqr_smax, sqr_smin, nsbin, nmu_bins, supp_sqr, mu_max, pimax,

--- a/theory/wp/countpairs_wp_impl.c.src
+++ b/theory/wp/countpairs_wp_impl.c.src
@@ -427,10 +427,13 @@ int countpairs_wp_DOUBLE(const int64_t ND, DOUBLE * restrict X, DOUBLE * restric
                     current_utc_time(&tcell_start);
                 }
 
-                const int status = wp_function_DOUBLE(this_cell_pair->x1, this_cell_pair->y1, this_cell_pair->z1,
-                                                      this_cell_pair->weights1, this_cell_pair->N1,
-                                                      this_cell_pair->x2, this_cell_pair->y2, this_cell_pair->z2,
-                                                      this_cell_pair->weights2, this_cell_pair->N2,
+                const int64_t icell = this_cell_pair->cellindex1;
+                const int64_t icell2 = this_cell_pair->cellindex2;
+                const cellarray_DOUBLE *first = &lattice[icell];
+                const cellarray_DOUBLE *second = &lattice[icell2];
+
+                const int status = wp_function_DOUBLE(first->x, first->y, first->z, &(first->weights), first->nelements, 
+                                                      second->x, second->y, second->z, &(second->weights), second->nelements, 
                                                       this_cell_pair->same_cell,
                                                       sqr_rpmax, sqr_rpmin, nrpbins, rupp_sqr, pimax,
                                                       this_cell_pair->xwrap, this_cell_pair->ywrap, this_cell_pair->zwrap,
@@ -448,7 +451,7 @@ int countpairs_wp_DOUBLE(const int64_t ND, DOUBLE * restrict X, DOUBLE * restric
                     current_utc_time(&tcell_end);
                     double time_in_ns = REALTIME_ELAPSED_NS(tcell_start, tcell_end);
                     struct api_cell_timings *base_cell = &(options->cell_timings[icellpair]);
-                    ASSIGN_CELL_TIMINGS(base_cell, this_cell_pair->N1, this_cell_pair->N2, time_in_ns,
+                    ASSIGN_CELL_TIMINGS(base_cell, first->nelements, second->nelements, time_in_ns,
                                         tid, this_cell_pair->cellindex1, this_cell_pair->cellindex2);
                 }
             }//abort-status

--- a/theory/xi/countpairs_xi_impl.c.src
+++ b/theory/xi/countpairs_xi_impl.c.src
@@ -395,10 +395,13 @@ int countpairs_xi_DOUBLE(const int64_t ND, DOUBLE * restrict X, DOUBLE * restric
                 DOUBLE *this_rpavg = options->need_avg_sep ? ravg:NULL;
                 DOUBLE *this_weightavg = need_weightavg ? weightavg:NULL;
 
-                const int status = xi_function_DOUBLE(this_cell_pair->x1, this_cell_pair->y1, this_cell_pair->z1,
-                                                      this_cell_pair->weights1, this_cell_pair->N1,
-                                                      this_cell_pair->x2, this_cell_pair->y2, this_cell_pair->z2,
-                                                      this_cell_pair->weights2, this_cell_pair->N2,
+                const int64_t icell = this_cell_pair->cellindex1;
+                const int64_t icell2 = this_cell_pair->cellindex2;
+                const cellarray_DOUBLE *first = &lattice[icell];
+                const cellarray_DOUBLE *second = &lattice[icell2];
+
+                const int status = xi_function_DOUBLE(first->x, first->y, first->z, &(first->weights), first->nelements,
+                                                      second->x, second->y, second->z, &(second->weights), second->nelements,
                                                       this_cell_pair->same_cell,
                                                       sqr_rmax, sqr_rmin, nbins, rupp_sqr,
                                                       this_cell_pair->xwrap, this_cell_pair->ywrap, this_cell_pair->zwrap,

--- a/utils/cell_pair.h.src
+++ b/utils/cell_pair.h.src
@@ -18,20 +18,7 @@ extern "C" {
 #include "weight_defs_DOUBLE.h"
 
 struct cell_pair_DOUBLE{
-    int64_t N1;
-    DOUBLE *x1;
-    DOUBLE *y1;
-    DOUBLE *z1;
-    int64_t *orig_index1;
-    weight_struct_DOUBLE *weights1;
     int64_t cellindex1;
-
-    int64_t N2;
-    DOUBLE *x2;
-    DOUBLE *y2;
-    DOUBLE *z2;
-    int64_t *orig_index2;
-    weight_struct_DOUBLE *weights2;
     int64_t cellindex2;
 
     DOUBLE xwrap;
@@ -47,16 +34,6 @@ struct cell_pair_DOUBLE{
     DOUBLE closest_z1;
 
     int8_t same_cell;
-    union{
-        int16_t xbin_offset;
-        int16_t ra_bin_offset;
-    };
-    union{
-        int16_t ybin_offset;
-        int16_t dec_bin_offset;
-    };
-    int16_t zbin_offset;
-    int8_t unused;//explicitly adding here for alignment
 };
 
 #ifdef __cplusplus

--- a/utils/defs.h
+++ b/utils/defs.h
@@ -19,7 +19,7 @@
 extern "C" {
 #endif
 
-#define API_VERSION          STR("2.3.0")
+#define API_VERSION          STR("2.3.1")
 
 typedef enum {
   DEFAULT=-42,/* present simply to make the enum a signed int*/

--- a/utils/gridlink_impl.c.src
+++ b/utils/gridlink_impl.c.src
@@ -428,9 +428,12 @@ struct cell_pair_DOUBLE * generate_cell_pairs_DOUBLE(struct cellarray_DOUBLE *la
     const int64_t nx_ngb = 2*xbin_refine_factor + 1;
     const int64_t ny_ngb = 2*ybin_refine_factor + 1;
     const int64_t nz_ngb = 2*zbin_refine_factor + 1;
-    const int64_t max_ngb_cells = nx_ngb * ny_ngb * nz_ngb;
+    const int64_t max_ngb_cells = nx_ngb * ny_ngb * nz_ngb - 1; // -1 for self
 
-    const int64_t max_num_cell_pairs = totncells * max_ngb_cells;
+    const int64_t num_self_pairs = totncells;
+    const int64_t num_nonself_pairs = totncells * max_ngb_cells / (1 + autocorr);
+
+    const int64_t max_num_cell_pairs = num_self_pairs + num_nonself_pairs;
     int64_t num_cell_pairs = 0;
     struct cell_pair_DOUBLE *all_cell_pairs = my_malloc(sizeof(*all_cell_pairs), max_num_cell_pairs);
     XRETURN(all_cell_pairs != NULL, NULL,

--- a/utils/gridlink_impl.c.src
+++ b/utils/gridlink_impl.c.src
@@ -430,6 +430,11 @@ struct cell_pair_DOUBLE * generate_cell_pairs_DOUBLE(struct cellarray_DOUBLE *la
     const int64_t nz_ngb = 2*zbin_refine_factor + 1;
     const int64_t max_ngb_cells = nx_ngb * ny_ngb * nz_ngb - 1; // -1 for self
 
+
+    if( ! (autocorr == 0 || autocorr == 1) ) {
+        fprintf(stderr,"Error: Strange value of autocorr = %d. Expected to receive either 1 (auto-correlations) or 0 (cross-correlations)\n", autocorr);
+        return NULL;
+    }
     const int64_t num_self_pairs = totncells;
     const int64_t num_nonself_pairs = totncells * max_ngb_cells / (1 + autocorr);
 
@@ -545,20 +550,7 @@ struct cell_pair_DOUBLE * generate_cell_pairs_DOUBLE(struct cellarray_DOUBLE *la
                     //If we have reached here, then this cell *MIGHT* have a pair. We
                     //need to add a cell-pair to the array of all cell-pairs
                     struct cell_pair_DOUBLE *this_cell_pair = &all_cell_pairs[num_cell_pairs];
-                    this_cell_pair->N1 = first->nelements;
-                    this_cell_pair->x1 = first->x;
-                    this_cell_pair->y1 = first->y;
-                    this_cell_pair->z1 = first->z;
-                    this_cell_pair->orig_index1 = first->original_index;
-                    this_cell_pair->weights1 = &first->weights;
                     this_cell_pair->cellindex1 = icell;
-
-                    this_cell_pair->N2 = second->nelements;
-                    this_cell_pair->x2 = second->x;
-                    this_cell_pair->y2 = second->y;
-                    this_cell_pair->z2 = second->z;
-                    this_cell_pair->orig_index2 = second->original_index;
-                    this_cell_pair->weights2 = &second->weights;
                     this_cell_pair->cellindex2 = icell2;
 
                     this_cell_pair->xwrap = off_xwrap;
@@ -572,10 +564,6 @@ struct cell_pair_DOUBLE * generate_cell_pairs_DOUBLE(struct cellarray_DOUBLE *la
                     this_cell_pair->closest_x1 = closest_x1;
                     this_cell_pair->closest_y1 = closest_y1;
                     this_cell_pair->closest_z1 = closest_z1;
-
-                    this_cell_pair->xbin_offset = iix;
-                    this_cell_pair->ybin_offset = iiy;
-                    this_cell_pair->zbin_offset = iiz;
 
                     this_cell_pair->same_cell = (autocorr == 1 && icell2 == icell) ? 1:0;
 

--- a/utils/gridlink_mocks_impl.c.src
+++ b/utils/gridlink_mocks_impl.c.src
@@ -430,9 +430,12 @@ struct cell_pair_DOUBLE * generate_cell_pairs_mocks_DOUBLE(struct cellarray_mock
     const int64_t nx_ngb = 2*xbin_refine_factor + 1;
     const int64_t ny_ngb = 2*ybin_refine_factor + 1;
     const int64_t nz_ngb = 2*zbin_refine_factor + 1;
-    const int64_t max_ngb_cells = nx_ngb * ny_ngb * nz_ngb;
+    const int64_t max_ngb_cells = nx_ngb * ny_ngb * nz_ngb - 1; // -1 for self
 
-    const int64_t max_num_cell_pairs = totncells * max_ngb_cells;
+    const int64_t num_self_pairs = totncells;
+    const int64_t num_nonself_pairs = totncells * max_ngb_cells / (autocorr + 1);
+
+    const int64_t max_num_cell_pairs = num_self_pairs + num_nonself_pairs;
     int64_t num_cell_pairs = 0;
     struct cell_pair_DOUBLE *all_cell_pairs = my_malloc(sizeof(*all_cell_pairs), max_num_cell_pairs);
     XRETURN(all_cell_pairs != NULL, NULL,
@@ -921,8 +924,13 @@ struct cell_pair_DOUBLE * generate_cell_pairs_mocks_theta_dec_DOUBLE(cellarray_m
      */
     const DOUBLE sqr_max_chord_sep = 2.0 * (1.0 - COSD(thetamax));
 
-    const int64_t max_ngb_cells = 2*dec_refine_factor + 1;
-    const int64_t max_num_cell_pairs = totncells * max_ngb_cells;
+    const int64_t max_ngb_cells = 2*dec_refine_factor;  // -1 for self
+
+    const int64_t num_self_pairs = totncells;
+    const int64_t num_nonself_pairs = totncells * max_ngb_cells / (autocorr + 1);
+
+    const int64_t max_num_cell_pairs = num_self_pairs + num_nonself_pairs;
+
     int64_t num_cell_pairs = 0;
     struct cell_pair_DOUBLE *all_cell_pairs = my_malloc(sizeof(*all_cell_pairs), max_num_cell_pairs);
     XRETURN(all_cell_pairs != NULL, NULL,

--- a/utils/gridlink_mocks_impl.c.src
+++ b/utils/gridlink_mocks_impl.c.src
@@ -432,6 +432,10 @@ struct cell_pair_DOUBLE * generate_cell_pairs_mocks_DOUBLE(struct cellarray_mock
     const int64_t nz_ngb = 2*zbin_refine_factor + 1;
     const int64_t max_ngb_cells = nx_ngb * ny_ngb * nz_ngb - 1; // -1 for self
 
+    if( ! (autocorr == 0 || autocorr == 1) ) {
+        fprintf(stderr,"Error: Strange value of autocorr = %d. Expected to receive either 1 (auto-correlations) or 0 (cross-correlations)\n", autocorr);
+        return NULL;
+    }
     const int64_t num_self_pairs = totncells;
     const int64_t num_nonself_pairs = totncells * max_ngb_cells / (autocorr + 1);
 
@@ -518,20 +522,7 @@ struct cell_pair_DOUBLE * generate_cell_pairs_mocks_DOUBLE(struct cellarray_mock
                             "Expected that the total number of cell pairs can be at most %"PRId64" but "
                             "currently have number of cell pairs = %"PRId64"\n", max_num_cell_pairs, num_cell_pairs);
                     struct cell_pair_DOUBLE *this_cell_pair = &all_cell_pairs[num_cell_pairs];
-                    this_cell_pair->N1 = first->nelements;
-                    this_cell_pair->x1 = first->x;
-                    this_cell_pair->y1 = first->y;
-                    this_cell_pair->z1 = first->z;
-                    this_cell_pair->orig_index1 = first->original_index;
-                    this_cell_pair->weights1 = &first->weights;
                     this_cell_pair->cellindex1 = icell;
-
-                    this_cell_pair->N2 = second->nelements;
-                    this_cell_pair->x2 = second->x;
-                    this_cell_pair->y2 = second->y;
-                    this_cell_pair->z2 = second->z;
-                    this_cell_pair->orig_index2 = second->original_index;
-                    this_cell_pair->weights2 = &second->weights;
                     this_cell_pair->cellindex2 = icell2;
 
                     this_cell_pair->min_dx = min_dx;
@@ -926,6 +917,10 @@ struct cell_pair_DOUBLE * generate_cell_pairs_mocks_theta_dec_DOUBLE(cellarray_m
 
     const int64_t max_ngb_cells = 2*dec_refine_factor;  // -1 for self
 
+    if( ! (autocorr == 0 || autocorr == 1) ) {
+        fprintf(stderr,"Error: Strange value of autocorr = %d. Expected to receive either 1 (auto-correlations) or 0 (cross-correlations)\n", autocorr);
+        return NULL;
+    }
     const int64_t num_self_pairs = totncells;
     const int64_t num_nonself_pairs = totncells * max_ngb_cells / (autocorr + 1);
 
@@ -984,20 +979,7 @@ struct cell_pair_DOUBLE * generate_cell_pairs_mocks_theta_dec_DOUBLE(cellarray_m
             //If we have reached here, then this cell *MIGHT* have a pair. We
             //need to add a cell-pair to the array of all cell-pairs
             struct cell_pair_DOUBLE *this_cell_pair = &all_cell_pairs[num_cell_pairs];
-            this_cell_pair->N1 = first->nelements;
-            this_cell_pair->x1 = first->x;
-            this_cell_pair->y1 = first->y;
-            this_cell_pair->z1 = first->z;
-            this_cell_pair->orig_index1 = first->original_index;
-            this_cell_pair->weights1 = &first->weights;
             this_cell_pair->cellindex1 = icell;
-
-            this_cell_pair->N2 = second->nelements;
-            this_cell_pair->x2 = second->x;
-            this_cell_pair->y2 = second->y;
-            this_cell_pair->z2 = second->z;
-            this_cell_pair->orig_index2 = second->original_index;
-            this_cell_pair->weights2 = &second->weights;
             this_cell_pair->cellindex2 = icell2;
 
             this_cell_pair->min_dx = min_dx;
@@ -1007,9 +989,6 @@ struct cell_pair_DOUBLE * generate_cell_pairs_mocks_theta_dec_DOUBLE(cellarray_m
             this_cell_pair->closest_x1 = closest_x1;
             this_cell_pair->closest_y1 = closest_y1;
             this_cell_pair->closest_z1 = closest_z1;
-
-            this_cell_pair->ra_bin_offset = 0;
-            this_cell_pair->dec_bin_offset = idec;
 
             this_cell_pair->same_cell = (autocorr == 1 && icell2 == icell) ? 1:0;
 
@@ -1659,20 +1638,7 @@ struct cell_pair_DOUBLE * generate_cell_pairs_mocks_theta_ra_dec_DOUBLE(cellarra
                     //If we have reached here, then this cell *MIGHT* have a pair. We
                     //need to add a cell-pair to the array of all cell-pairs
                     struct cell_pair_DOUBLE *this_cell_pair = &all_cell_pairs[num_cell_pairs];
-                    this_cell_pair->N1 = first->nelements;
-                    this_cell_pair->x1 = first->x;
-                    this_cell_pair->y1 = first->y;
-                    this_cell_pair->z1 = first->z;
-                    this_cell_pair->orig_index1 = first->original_index;
-                    this_cell_pair->weights1 = &first->weights;
                     this_cell_pair->cellindex1 = icell;
-
-                    this_cell_pair->N2 = second->nelements;
-                    this_cell_pair->x2 = second->x;
-                    this_cell_pair->y2 = second->y;
-                    this_cell_pair->z2 = second->z;
-                    this_cell_pair->orig_index2 = second->original_index;
-                    this_cell_pair->weights2 = &second->weights;
                     this_cell_pair->cellindex2 = icell2;
 
                     this_cell_pair->min_dx = min_dx;
@@ -1682,9 +1648,6 @@ struct cell_pair_DOUBLE * generate_cell_pairs_mocks_theta_ra_dec_DOUBLE(cellarra
                     this_cell_pair->closest_x1 = closest_x1;
                     this_cell_pair->closest_y1 = closest_y1;
                     this_cell_pair->closest_z1 = closest_z1;
-
-                    this_cell_pair->ra_bin_offset = iira;
-                    this_cell_pair->dec_bin_offset = dec_refine;
 
                     this_cell_pair->same_cell = (autocorr == 1 && icell2 == icell) ? 1:0;
 


### PR DESCRIPTION
Gridlink has a rather large memory footprint after the min_sep_opt changes.  One way to reduce this is by slimming down the `cell_pair` strut to hold only pair info, and not cell info (#185).  But for autocorrelations, there's another factor-of-2 savings possible from the fact that we're presently allocating enough memory to double-count every cell pair, even though we only singly count them.  This PR implements that memory saving for autocorrelations.

@manodeep: I think it should be obvious pretty quickly if I messed up the `max_num_cell_pairs` calculation, since we have an explicit `num_cell_pairs < max_num_cell_pairs` check.  Let's see what Travis says (local tests are passing).

Also feel free to tack on the `cell_pair` slimming optimizations to this PR.