### PR TITLE
GNU Assembler bug workaround

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -25,6 +25,7 @@ Enhancements
 Bug fixes
 ----------
 - Incorrect calculations for non-native endian data [#191]
+- Workaround for GNU Assembler bug causing incorrect calculations [#196]
 
 
 

--- a/common.mk
+++ b/common.mk
@@ -66,33 +66,25 @@ endif
 ## Only set everything if the command is not "make clean" (or related to "make clean")
 ifeq ($(DO_CHECKS), 1)
   UNAME := $(shell uname)
-  ## Colored text output
-  ## Taken from: http://stackoverflow.com/questions/24144440/color-highlighting-of-makefile-warnings-and-errors
-  ## Except, you have to use "echo -e" on linux and "echo" on Mac
-  ECHO_COMMAND := echo -e
-  ifeq ($(UNAME), Darwin)
-    ECHO_COMMAND := echo
-  endif
-  ifeq ($(TRAVIS_OS_NAME), linux)
-    ECHO_COMMAND := echo
-  endif
 
   ifneq ($(UNAME), Darwin)
     CLINK += -lrt # need real time library for the nano-second timers. Not required on OSX
   endif
 
+  ## Colored text output
+  ## https://stackoverflow.com/questions/4332478/read-the-current-text-color-in-a-xterm/4332530#4332530
   ## Broadly speaking, here's the color convention (not strictly adhered to yet):
   ## green - shell commands
   ## red - error messages
   ## magenta - general highlight
   ## blue - related to code/compile option
   ## bold - only used with printing out compilation options
-  ccred:=$(shell $(ECHO_COMMAND) "\033[0;31m")
-  ccmagenta:=$(shell $(ECHO_COMMAND) "\033[0;35m")
-  ccgreen:=$(shell $(ECHO_COMMAND) "\033[0;32m")
-  ccblue:=$(shell $(ECHO_COMMAND) "\033[0;34m")
-  ccreset:=$(shell $(ECHO_COMMAND) "\033[0;0m")
-  boldfont:=$(shell $(ECHO_COMMAND) "\033[1m")
+  ccred:=$(shell tput setaf 1)
+  ccmagenta:=$(shell tput setaf 5)
+  ccgreen:=$(shell tput setaf 2)
+  ccblue:=$(shell tput setaf 4)
+  ccreset:=$(shell tput sgr0)
+  boldfont:=$(shell tput bold)
   ## end of colored text output
 
   ## First check make version. Versions of make older than 3.80 will crash
@@ -614,7 +606,7 @@ ifeq ($(DO_CHECKS), 1)
     ifeq (USE_MKL,$(findstring USE_MKL,$(OPT)))
       MAKEFILE_VARS += BLAS_INCLUDE BLAS_LINK
     endif
-    tabvar:= $(shell $(ECHO_COMMAND) "\t")
+    tabvar:= $(shell printf "\t")
     $(info )
     $(info $(ccmagenta)$(boldfont)-------COMPILE SETTINGS------------$(ccreset))
     $(foreach var, $(MAKEFILE_VARS), $(info $(tabvar) $(boldfont)$(var)$(ccreset)$(tabvar)$(tabvar) = ["$(ccblue)$(boldfont)${${var}}$(ccreset)"]))

--- a/common.mk
+++ b/common.mk
@@ -394,7 +394,7 @@ ifeq ($(DO_CHECKS), 1)
       CFLAGS += -mno-avx512f
 
       ifneq ($(GAS_BUG_WARNING_PRINTED),1)
-        $(warning $(ccmagenta)DISABLING AVX-512 SUPPORT DUE TO GNU ASSEMBLER BUG.  UPGRADE TO BINUTILS >=2.32 TO FIX THIS.$(ccreset))
+        $(warning $(ccred)DISABLING AVX-512 SUPPORT DUE TO GNU ASSEMBLER BUG.  UPGRADE TO BINUTILS >=2.32 TO FIX THIS.$(ccreset))
       endif
       export GAS_BUG_WARNING_PRINTED := 1
     endif

--- a/common.mk
+++ b/common.mk
@@ -385,11 +385,11 @@ ifeq ($(DO_CHECKS), 1)
   # This works for gcc and icc.
   # clang typically uses its own assembler, but if it is using the system assembler, this will also detect that.
   # See: https://github.com/manodeep/Corrfunc/issues/193
-  GAS_BUG_DISABLE_AVX512 := $(shell $(CC) $(CFLAGS) -xc -Wa,-v -c /dev/null -o /dev/null 2>&1 | \grep -Pcm1 'GNU assembler version (2\.30|2\.31|2\.31\.1)(\s|$$)')
+  GAS_BUG_DISABLE_AVX512 := $(shell $(CC) $(CFLAGS) -xc -Wa,-v -c /dev/null -o /dev/null 2>&1 | \grep -Ecm1 'GNU assembler version (2\.30|2\.31|2\.31\.1)(\s|$$)')
 
   ifeq ($(GAS_BUG_DISABLE_AVX512),1)
     # Did the compiler support AVX-512 in the first place? Otherwise -mno-avx512f is not a valid option!
-    CC_SUPPORTS_AVX512 := $(shell $(CC) $(CFLAGS) -dM -E - < /dev/null | \grep -Pcm1 __AVX512F__)
+    CC_SUPPORTS_AVX512 := $(shell $(CC) $(CFLAGS) -dM -E - < /dev/null | \grep -Ecm1 __AVX512F__)
     ifeq ($(CC_SUPPORTS_AVX512),1)
       CFLAGS += -mno-avx512f
 

--- a/common.mk
+++ b/common.mk
@@ -247,14 +247,14 @@ ifeq ($(DO_CHECKS), 1)
   endif
   ## done with check for conflicting options
 
-  # The GNU Assembler (GAS) has an AVX-512 bug in versions 2.30 and 2.31
+  # The GNU Assembler (GAS) has an AVX-512 bug in versions 2.30 to 2.31.1
   # So we turn off AVX-512 if one of the bugged GAS versions is present.
   # Note that both gcc and icc might use GAS!  Clang has its own assembler.
   # If we are using the clang assembler,  we will detect this below and re-enable AVX-512
   # See: https://github.com/manodeep/Corrfunc/issues/193
-  GAS_VERSION := $(shell as --version | head -n1 |\grep -oP '\d+\.\d+$$')
+  GAS_VERSION := $(shell as --version | head -n1 | \grep -P 'GNU assembler' |\grep -oP '\d+\.\d+$$')
   GAS_BUG_DISABLE_AVX512 := 0
-  ifeq ($(GAS_VERSION),$(filter $(GAS_VERSION),2.30 2.31))
+  ifneq (,$(filter $(GAS_VERSION),2.30 2.31 2.31.1))
     GAS_BUG_DISABLE_AVX512 := 1
   endif
 
@@ -262,7 +262,7 @@ ifeq ($(DO_CHECKS), 1)
     # Normally, one would use -xHost with icc instead of -march=native
     # But -xHost does not allow you to later turn off just AVX-512,
     # which we may decide is necessary if the GAS bug is present
-    CFLAGS := -march=native
+    CFLAGS += -march=native
     ifeq (USE_OMP,$(findstring USE_OMP,$(OPT)))
       CFLAGS += -qopenmp
       CLINK  += -qopenmp
@@ -406,7 +406,7 @@ ifeq ($(DO_CHECKS), 1)
       CFLAGS += -mno-avx512f
 
       ifneq ($(GAS_BUG_WARNING_PRINTED),1)
-        $(warning $(ccmagenta)DISABLING AVX-512 SUPPORT DUE TO GNU ASSEMBLER BUG$(ccreset))
+        $(warning $(ccmagenta)DISABLING AVX-512 SUPPORT DUE TO GNU ASSEMBLER BUG.  UPGRADE TO BINUTILS >=2.32 TO FIX THIS.$(ccreset))
       endif
       export GAS_BUG_WARNING_PRINTED := 1
     endif

--- a/common.mk
+++ b/common.mk
@@ -394,9 +394,10 @@ ifeq ($(DO_CHECKS), 1)
     CC_SUPPORTS_AVX512 := $(shell $(CC) $(CFLAGS) -dM -E - < /dev/null | \grep -Ecm1 __AVX512F__)
     ifeq ($(CC_SUPPORTS_AVX512),1)
       ifeq ($(shell test 0$(ICC_MAJOR_VER) -ge 019; echo $$?),0)
-        CFLAGS += -xCORE-AVX2
-      else
+      	# If gcc, clang, or new icc, we can use this
         CFLAGS += -mno-avx512f
+      else
+        CFLAGS += -xCORE-AVX2
       endif
 
       ifneq ($(GAS_BUG_WARNING_PRINTED),1)


### PR DESCRIPTION
This fixes #193 by querying the compiler to see if it is using a known-bad version of the GNU Assembler (GAS) under the hood.  If so, AVX-512 is disabled.  This works for `gcc` and `icc` (both of which use GAS under the hood), and `clang` if it is using GAS instead of its integrated assembler.

If AVX-512 is disabled, a warning will be printed during compilation.  I think the pip installation will still be silent though, which may not be what we want.

I also had to change `icc -xHost` to `icc -march=native`.  It doesn't seem possible to disable AVX-512F (with `-mno-avx512f`, for example) with the former, only the latter.  I don't think it will make a big difference.

There was also a bug in the `icc` compiler options: we were using `-xHost -xCORE-AVX512` indiscriminately, which will always generate AVX-512 instructions, even on non-AVX-512 machines!

I also changed the compilation output coloring to use `tput` instead of `echo` and escape sequences.  On Ubuntu, I was getting tons of `-e`s in my output because `sh` is actually `dash`, and `echo` in `dash` doesn't have a `-e` flag (it's enabled by default).  `tput` seemed like a more robust solution than trying to detect `dash`, but let me know what you think.