### PR TITLE
Correctly convert counts to cf when doing an autocorr

### DIFF
--- a/Corrfunc/utils.py
+++ b/Corrfunc/utils.py
@@ -61,6 +61,9 @@ def convert_3d_counts_to_cf(ND1, ND2, NR1, NR2,
         The kind of estimator to use for computing the correlation
         function. Currently, only supports Landy-Szalay
 
+    autocorr: bool, default=False
+        Whether the counts are from an autocorrelation
+
     Returns
     ---------
 
@@ -171,7 +174,7 @@ def convert_3d_counts_to_cf(ND1, ND2, NR1, NR2,
 def convert_rp_pi_counts_to_wp(ND1, ND2, NR1, NR2,
                                D1D2, D1R2, D2R1, R1R2,
                                nrpbins, pimax, dpi=1.0,
-                               estimator='LS'):
+                               estimator='LS', autocorr=False):
     """
     Converts raw pair counts to a correlation function.
 
@@ -217,6 +220,10 @@ def convert_rp_pi_counts_to_wp(ND1, ND2, NR1, NR2,
     estimator: string, default='LS' (Landy-Szalay)
         The kind of estimator to use for computing the correlation
         function. Currently, only supports Landy-Szalay
+
+    autocorr: bool, default=False
+        Whether the counts are from an autocorrelation
+
 
     Returns
     ---------
@@ -297,7 +304,7 @@ def convert_rp_pi_counts_to_wp(ND1, ND2, NR1, NR2,
 
     xirppi = convert_3d_counts_to_cf(ND1, ND2, NR1, NR2,
                                      D1D2, D1R2, D2R1, R1R2,
-                                     estimator=estimator)
+                                     estimator=estimator, autocorr=autocorr)
     wp = np.empty(nrpbins)
     npibins = len(xirppi) // nrpbins
     if ((npibins * nrpbins) != len(xirppi)):

--- a/Corrfunc/utils.py
+++ b/Corrfunc/utils.py
@@ -149,14 +149,16 @@ def convert_3d_counts_to_cf(ND1, ND2, NR1, NR2,
             fN3 = (np.float(NR1) - 1) / np.float(ND1)
             cf[nonzero] = (fN1 * fN2 * pair_counts['D1D2'][nonzero] -
                            2 * fN3 * pair_counts['D1R2'][nonzero] +
-                           pair_counts['R1R2'][nonzero]) / pair_counts['R1R2'][nonzero]
+                           pair_counts['R1R2'][nonzero]
+                           ) / pair_counts['R1R2'][nonzero]
         else:
             fN1 = np.float(NR1) / np.float(ND1)
             fN2 = np.float(NR2) / np.float(ND2)
             cf[nonzero] = (fN1 * fN2 * pair_counts['D1D2'][nonzero] -
                            fN1 * pair_counts['D1R2'][nonzero] -
                            fN2 * pair_counts['D2R1'][nonzero] +
-                           pair_counts['R1R2'][nonzero]) / pair_counts['R1R2'][nonzero]
+                           pair_counts['R1R2'][nonzero]
+                           ) / pair_counts['R1R2'][nonzero]
         if len(cf) != nbins:
             msg = 'Bug in code. Calculated correlation function does not '\
                   'have the same number of bins as input arrays. Input bins '\

--- a/Corrfunc/utils.py
+++ b/Corrfunc/utils.py
@@ -23,7 +23,7 @@ except NameError:
 
 def convert_3d_counts_to_cf(ND1, ND2, NR1, NR2,
                             D1D2, D1R2, D2R1, R1R2,
-                            estimator='LS'):
+                            estimator='LS', autocorr=False):
     """
     Converts raw pair counts to a correlation function.
 
@@ -138,14 +138,22 @@ def convert_3d_counts_to_cf(ND1, ND2, NR1, NR2,
 
     nonzero = pair_counts['R1R2'] > 0
     if 'LS' in estimator or 'Landy' in estimator:
-        fN1 = np.float(NR1) / np.float(ND1)
-        fN2 = np.float(NR2) / np.float(ND2)
         cf = np.zeros(nbins)
         cf[:] = np.nan
-        cf[nonzero] = (fN1 * fN2 * pair_counts['D1D2'][nonzero] -
-                       fN1 * pair_counts['D1R2'][nonzero] -
-                       fN2 * pair_counts['D2R1'][nonzero] +
-                       pair_counts['R1R2'][nonzero]) / pair_counts['R1R2'][nonzero]
+        if autocorr:
+            fN1 = np.float(NR1) / np.float(ND1)
+            fN2 = (np.float(NR1) - 1) / (np.float(ND1) - 1)
+            fN3 = (np.float(NR1) - 1) / np.float(ND1)
+            cf[nonzero] = (fN1 * fN2 * pair_counts['D1D2'][nonzero] -
+                           2 * fN3 * pair_counts['D1R2'][nonzero] +
+                           pair_counts['R1R2'][nonzero]) / pair_counts['R1R2'][nonzero]
+        else:
+            fN1 = np.float(NR1) / np.float(ND1)
+            fN2 = np.float(NR2) / np.float(ND2)
+            cf[nonzero] = (fN1 * fN2 * pair_counts['D1D2'][nonzero] -
+                           fN1 * pair_counts['D1R2'][nonzero] -
+                           fN2 * pair_counts['D2R1'][nonzero] +
+                           pair_counts['R1R2'][nonzero]) / pair_counts['R1R2'][nonzero]
         if len(cf) != nbins:
             msg = 'Bug in code. Calculated correlation function does not '\
                   'have the same number of bins as input arrays. Input bins '\


### PR DESCRIPTION
I think that the current way that Corrfunc converts counts to a correlation function isn't quite right for autocorrelations. I think the normalization is slightly off (see equation 3 in the [LS paper](http://adsabs.harvard.edu/doi/10.1086/172900)).

The effect of this is totally negligible when the number of pairs is high, and very small even when it isn't so this isn't a big deal... But I was confused why things weren't quite as I expected and it seems worth a fix.

Please let me know I am right about this - there's always a good change I've misunderstood something! This change is also pretty rough at the moment - I just wanted to have something to show. I'm happy to clean it up, write tests, etc later but didn't want to do that before checking this made sense!

Thanks!