### PR TITLE
Add find_fastest_DDtheta_mocks_bin_refs() function to Corrfunc/mocks/DDtheta_mocks

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -17,7 +17,7 @@ This is a bug-fix release and contains general code quality improvements.
 
 Enhancements
 ------------
-
+- Add find_fastest_DDtheta_mocks_bin_refs() function to Corrfunc/mocks/DDtheta_mocks [#216]
 
 
 Bug fixes

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -17,7 +17,7 @@ This is a bug-fix release and contains general code quality improvements.
 
 Enhancements
 ------------
-- Add find_fastest_DDtheta_mocks_bin_refs() function to Corrfunc/mocks/DDtheta_mocks [#216]
+- A new helper routine to find the combination of (RA, DEC) refinements that produces fastest runtime in ``DDtheta_mocks`` [#216]
 
 
 Bug fixes

--- a/Corrfunc/mocks/DDtheta_mocks.py
+++ b/Corrfunc/mocks/DDtheta_mocks.py
@@ -506,8 +506,6 @@ def find_fastest_DDtheta_mocks_bin_refs(autocorr, nthreads, binfile,
     doctest is skipped for this function.
     """
 
-    import logging
-
     weights1 = None
     weights2 = None
     weight_type = None

--- a/Corrfunc/mocks/DDtheta_mocks.py
+++ b/Corrfunc/mocks/DDtheta_mocks.py
@@ -266,32 +266,31 @@ def DDtheta_mocks(autocorr, nthreads, binfile,
       7.079458  10.000000   8.622400   37842502   1.000000
 
     """
-
     try:
-        from Corrfunc._countpairs_mocks import countpairs_theta_mocks as \
+        from Corrfunc._countpairs_mocks import countpairs_theta_mocks as\
             DDtheta_mocks_extn
     except ImportError:
-        msg = "Could not import the C extension for the angular " \
+        msg = "Could not import the C extension for the angular "\
               "correlation function for mocks."
         raise ImportError(msg)
 
     import numpy as np
-    from Corrfunc.utils import translate_isa_string_to_enum, fix_ra_dec, \
-        return_file_with_rbins, convert_to_native_endian, \
+    from Corrfunc.utils import translate_isa_string_to_enum, fix_ra_dec,\
+        return_file_with_rbins, convert_to_native_endian,\
         sys_pipes, process_weights
     from future.utils import bytes_to_native_str
 
     if autocorr == 0:
         if RA2 is None or DEC2 is None:
-            msg = "Must pass valid arrays for RA2/DEC2 for " \
+            msg = "Must pass valid arrays for RA2/DEC2 for "\
                   "computing cross-correlation"
             raise ValueError(msg)
     else:
         RA2 = np.empty(1)
         DEC2 = np.empty(1)
 
-    weights1, weights2 = \
-        process_weights(weights1, weights2, RA1, RA2, weight_type, autocorr)
+    weights1, weights2 = process_weights(weights1, weights2,
+                                         RA1, RA2, weight_type, autocorr)
 
     # Ensure all input arrays are native endian
     RA1, DEC1, weights1, RA2, DEC2, weights2 = [
@@ -484,7 +483,7 @@ def find_fastest_DDtheta_mocks_bin_refs(autocorr, nthreads, binfile,
     >>> from math import pi
     >>> from os.path import dirname, abspath, join as pjoin
     >>> import Corrfunc
-    >>> from Corrfunc.mocks.DDtheta_mocks \
+    >>> from Corrfunc.mocks.DDtheta_mocks\
         import find_fastest_DDtheta_mocks_bin_refs
     >>> binfile = pjoin(dirname(abspath(Corrfunc.__file__)),
     ...                 "../mocks/tests/", "angular_bins")
@@ -496,8 +495,8 @@ def find_fastest_DDtheta_mocks_bin_refs(autocorr, nthreads, binfile,
     >>> cos_theta = np.random.uniform(-1.0, 1.0, N)
     >>> DEC1 = 90.0 - np.arccos(cos_theta)*180.0/pi
     >>> autocorr = 1
-    >>> best, _ = find_fastest_DDtheta_mocks_bin_refs(autocorr, nthreads, \
-    ...                                               binfile, RA1, DEC1, \
+    >>> best, _ = find_fastest_DDtheta_mocks_bin_refs(autocorr, nthreads,\
+    ...                                               binfile, RA1, DEC1,\
     ...                                               return_runtimes=True)
     >>> print(best) # doctest:+SKIP
     (2, 1)
@@ -511,15 +510,15 @@ def find_fastest_DDtheta_mocks_bin_refs(autocorr, nthreads, binfile,
     weight_type = None
 
     try:
-        from Corrfunc._countpairs_mocks import countpairs_theta_mocks as \
+        from Corrfunc._countpairs_mocks import countpairs_theta_mocks as\
             DDtheta_mocks_extn
     except ImportError:
-        msg0 = "Could not import the C extension for the angular " \
+        msg0 = "Could not import the C extension for the angular "\
               "correlation function for mocks."
         raise ImportError(msg0)
 
     import numpy as np
-    from Corrfunc.utils import translate_isa_string_to_enum, fix_ra_dec, \
+    from Corrfunc.utils import translate_isa_string_to_enum, fix_ra_dec,\
         return_file_with_rbins, convert_to_native_endian, process_weights
     from future.utils import bytes_to_native_str
     import itertools
@@ -527,7 +526,7 @@ def find_fastest_DDtheta_mocks_bin_refs(autocorr, nthreads, binfile,
 
     if autocorr == 0:
         if RA2 is None or DEC2 is None:
-            msg1 = "Must pass valid arrays for RA2/DEC2 for " \
+            msg1 = "Must pass valid arrays for RA2/DEC2 for "\
                   "computing cross-correlation."
             raise ValueError(msg1)
     else:
@@ -538,17 +537,17 @@ def find_fastest_DDtheta_mocks_bin_refs(autocorr, nthreads, binfile,
         link_in_dec = True
 
     if link_in_dec is False and link_in_ra is False:
-        msg2 = "Warning: Brute-force calculation without any gridding " \
-               "is forced, as link_in_dec and link_in_ra are both set " \
-               "to False. Please be sure to turn on at least link_in_dec, " \
+        msg2 = "Warning: Brute-force calculation without any gridding "\
+               "is forced, as link_in_dec and link_in_ra are both set "\
+               "to False. Please be sure to turn on at least link_in_dec, "\
                "or both link_in_dec and link_in_ra on."
         raise ValueError(msg2)
 
     if link_in_dec is True:
         if link_in_ra is True:
 
-            weights1, weights2 = \
-                process_weights(weights1, weights2, RA1, RA2, weight_type, autocorr)
+            weights1, weights2 = process_weights(weights1, weights2, RA1, RA2,
+                                                 weight_type, autocorr)
 
             # Ensure all input arrays are native endian
             RA1, DEC1, weights1, RA2, DEC2, weights2 = [
@@ -597,7 +596,7 @@ def find_fastest_DDtheta_mocks_bin_refs(autocorr, nthreads, binfile,
                     t1 = time.time()
 
                     if extn_results is None:
-                        msg4 = "RuntimeError occurred with perms = ({0}, {1})". \
+                        msg4 = "RuntimeError occurred with perms = ({0}, {1})".\
                             format(nRA, nDEC)
                         print(msg4)
                         print("Continuing...")
@@ -640,14 +639,14 @@ def find_fastest_DDtheta_mocks_bin_refs(autocorr, nthreads, binfile,
     if link_in_dec is True:
         if link_in_ra is False:
 
-            msg3 = "Info: Gridding in the declination only, as link_in_dec " \
-                   "is set to True while link_in_ra is set to False. " \
-                   "Thus looping is only needed over the range of " \
+            msg3 = "Info: Gridding in the declination only, as link_in_dec "\
+                   "is set to True while link_in_ra is set to False. "\
+                   "Thus looping is only needed over the range of "\
                    "(min, max) bin, with refinements in the declination."
             print(msg3)
 
-            weights1, weights2 = \
-                process_weights(weights1, weights2, RA1, RA2, weight_type, autocorr)
+            weights1, weights2 = process_weights(weights1, weights2, RA1, RA2,
+                                                 weight_type, autocorr)
 
             # Ensure all input arrays are native endian
             RA1, DEC1, weights1, RA2, DEC2, weights2 = [
@@ -696,7 +695,7 @@ def find_fastest_DDtheta_mocks_bin_refs(autocorr, nthreads, binfile,
                     t1 = time.time()
 
                     if extn_results is None:
-                        msg4 = "RuntimeError occurred with perms = ({0}, {1})". \
+                        msg4 = "RuntimeError occurred with perms = ({0}, {1})".\
                             format(nRA, nDEC)
                         print(msg4)
                         print("Continuing...")

--- a/Corrfunc/mocks/DDtheta_mocks.py
+++ b/Corrfunc/mocks/DDtheta_mocks.py
@@ -571,7 +571,7 @@ def find_fastest_DDtheta_mocks_bin_refs(autocorr, nthreads, binfile,
     if link_in_ra is True:
         link_in_dec = True
 
-    if link_in_dec is False and link_in_ra is False:
+    if not link_in_dec:
         msg = "Error: Brute-force calculation without any gridding " \
               "is forced, as link_in_dec and link_in_ra are both set " \
               "to False. Please set at least one of link_in_dec, link_in_ra=True " \

--- a/Corrfunc/mocks/DDtheta_mocks.py
+++ b/Corrfunc/mocks/DDtheta_mocks.py
@@ -484,7 +484,7 @@ def find_fastest_DDtheta_mocks_bin_refs(autocorr, nthreads, binfile,
     >>> from math import pi
     >>> from os.path import dirname, abspath, join as pjoin
     >>> import Corrfunc
-    >>> from Corrfunc.mocks.DDtheta_mocks\
+    >>> from Corrfunc.mocks.DDtheta_mocks \
         import find_fastest_DDtheta_mocks_bin_refs
     >>> binfile = pjoin(dirname(abspath(Corrfunc.__file__)),
     ...                 "../mocks/tests/", "angular_bins")
@@ -574,7 +574,7 @@ def find_fastest_DDtheta_mocks_bin_refs(autocorr, nthreads, binfile,
                "or both link_in_dec and link_in_ra on."
         raise ValueError(msg2)
 
-    if link_in_ra is True:
+    if link_in_ra:
         for ii, (nRA, nDEC) in enumerate(bin_ref_perms):
             total_runtime = 0.0
             total_sqr_runtime = 0.0
@@ -640,6 +640,8 @@ def find_fastest_DDtheta_mocks_bin_refs(autocorr, nthreads, binfile,
                    "Thus looping is only needed over the range of "\
                    "(min, max) bin, with refinements in the declination."
             print(msg3)
+
+            # bin_ref_perms = [(None, x) for x in bin_ref_perms]
 
             for ii, (nRA, nDEC) in enumerate(bin_ref_perms):
                 total_runtime = 0.0

--- a/Corrfunc/mocks/DDtheta_mocks.py
+++ b/Corrfunc/mocks/DDtheta_mocks.py
@@ -539,7 +539,7 @@ def find_fastest_DDtheta_mocks_bin_refs(autocorr, nthreads, binfile,
     if link_in_ra is True:
         link_in_dec = True
 
-    if link_in_dec is False & link_in_ra is False:
+    if link_in_dec is False and link_in_ra is False:
         msg2 = "Warning: Brute-force calculation without any gridding " \
                "is forced,as link_in_dec and link_in_ra are both set " \
                "to False. Please be sure to turn on at least link_in_dec," \

--- a/Corrfunc/mocks/DDtheta_mocks.py
+++ b/Corrfunc/mocks/DDtheta_mocks.py
@@ -549,20 +549,17 @@ def find_fastest_DDtheta_mocks_bin_refs(autocorr, nthreads, binfile,
     bin_refs = np.arange(1, maxbinref + 1)
     if link_in_ra:
         bin_ref_perms = itertools.product(bin_refs, bin_refs)
+        nperms = maxbinref ** 2
 
-        dtype = np.dtype([(bytes_to_native_str(b'nRA'), np.int),
-                          (bytes_to_native_str(b'nDEC'), np.int),
-                          (bytes_to_native_str(b'avg_time'), np.float),
-                          (bytes_to_native_str(b'sigma_time'), np.float)])
-        all_runtimes = np.zeros(maxbinref ** 2, dtype=dtype)
     else:
         bin_ref_perms = [(1, binref) for binref in bin_refs]
+        nperms = maxbinref ** 1
 
-        dtype = np.dtype([(bytes_to_native_str(b'nRA'), np.int),
-                          (bytes_to_native_str(b'nDEC'), np.int),
-                          (bytes_to_native_str(b'avg_time'), np.float),
-                          (bytes_to_native_str(b'sigma_time'), np.float)])
-        all_runtimes = np.zeros(maxbinref ** 1, dtype=dtype)
+    dtype = np.dtype([(bytes_to_native_str(b'nRA'), np.int),
+                      (bytes_to_native_str(b'nDEC'), np.int),
+                      (bytes_to_native_str(b'avg_time'), np.float),
+                      (bytes_to_native_str(b'sigma_time'), np.float)])
+    all_runtimes = np.zeros(nperms, dtype=dtype)
     all_runtimes[:] = np.inf
 
     if autocorr == 0:

--- a/Corrfunc/mocks/DDtheta_mocks.py
+++ b/Corrfunc/mocks/DDtheta_mocks.py
@@ -294,8 +294,8 @@ def DDtheta_mocks(autocorr, nthreads, binfile,
 
     # Ensure all input arrays are native endian
     RA1, DEC1, weights1, RA2, DEC2, weights2 = [
-        convert_to_native_endian(arr, warn=True) for arr in
-        [RA1, DEC1, weights1, RA2, DEC2, weights2]]
+            convert_to_native_endian(arr, warn=True) for arr in
+            [RA1, DEC1, weights1, RA2, DEC2, weights2]]
 
     fix_ra_dec(RA1, DEC1)
     if autocorr == 0:
@@ -314,21 +314,20 @@ def DDtheta_mocks(autocorr, nthreads, binfile,
     integer_isa = translate_isa_string_to_enum(isa)
     rbinfile, delete_after_use = return_file_with_rbins(binfile)
     with sys_pipes():
-        extn_results = DDtheta_mocks_extn(
-            autocorr, nthreads, rbinfile,
-            RA1, DEC1,
-            verbose=verbose,
-            link_in_dec=link_in_dec,
-            link_in_ra=link_in_ra,
-            output_thetaavg=output_thetaavg,
-            fast_acos=fast_acos,
-            ra_refine_factor=ra_refine_factor,
-            dec_refine_factor=dec_refine_factor,
-            max_cells_per_dim=max_cells_per_dim,
-            copy_particles=copy_particles,
-            enable_min_sep_opt=enable_min_sep_opt,
-            c_api_timer=c_api_timer,
-            isa=integer_isa, **kwargs)
+        extn_results = DDtheta_mocks_extn(autocorr, nthreads, rbinfile,
+                                          RA1, DEC1,
+                                          verbose=verbose,
+                                          link_in_dec=link_in_dec,
+                                          link_in_ra=link_in_ra,
+                                          output_thetaavg=output_thetaavg,
+                                          fast_acos=fast_acos,
+                                          ra_refine_factor=ra_refine_factor,
+                                          dec_refine_factor=dec_refine_factor,
+                                          max_cells_per_dim=max_cells_per_dim,
+                                          copy_particles=copy_particles,
+                                          enable_min_sep_opt=enable_min_sep_opt,
+                                          c_api_timer=c_api_timer,
+                                          isa=integer_isa, **kwargs)
     if extn_results is None:
         msg = "RuntimeError occurred"
         raise RuntimeError(msg)
@@ -581,17 +580,16 @@ def find_fastest_DDtheta_mocks_bin_refs(autocorr, nthreads, binfile,
             total_sqr_runtime = 0.0
             for _ in range(nrepeats):
                 t0 = time.time()
-                extn_results = DDtheta_mocks_extn(
-                    autocorr, nthreads, rbinfile,
-                    RA1, DEC1, RA2, DEC2,
-                    link_in_dec=link_in_dec,
-                    link_in_ra=link_in_ra,
-                    verbose=verbose,
-                    output_thetaavg=output_thetaavg,
-                    ra_refine_factor=nRA,
-                    dec_refine_factor=nDEC,
-                    max_cells_per_dim=max_cells_per_dim,
-                    isa=integer_isa)
+                extn_results = DDtheta_mocks_extn(autocorr, nthreads, rbinfile,
+                                                  RA1, DEC1, RA2, DEC2,
+                                                  link_in_dec=link_in_dec,
+                                                  link_in_ra=link_in_ra,
+                                                  verbose=verbose,
+                                                  output_thetaavg=output_thetaavg,
+                                                  ra_refine_factor=nRA,
+                                                  dec_refine_factor=nDEC,
+                                                  max_cells_per_dim=max_cells_per_dim,
+                                                  isa=integer_isa)
                 t1 = time.time()
 
                 if extn_results is None:

--- a/Corrfunc/mocks/DDtheta_mocks.py
+++ b/Corrfunc/mocks/DDtheta_mocks.py
@@ -301,7 +301,7 @@ def DDtheta_mocks(autocorr, nthreads, binfile,
     if autocorr == 0:
         fix_ra_dec(RA2, DEC2)
 
-    if link_in_ra is True:
+    if link_in_ra:
         link_in_dec = True
 
     # Passing None parameters breaks the parsing code, so avoid this
@@ -550,10 +550,9 @@ def find_fastest_DDtheta_mocks_bin_refs(autocorr, nthreads, binfile,
     if link_in_ra:
         bin_ref_perms = itertools.product(bin_refs, bin_refs)
         nperms = maxbinref ** 2
-
     else:
         bin_ref_perms = [(1, binref) for binref in bin_refs]
-        nperms = maxbinref ** 1
+        nperms = maxbinref
 
     dtype = np.dtype([(bytes_to_native_str(b'nRA'), np.int),
                       (bytes_to_native_str(b'nDEC'), np.int),
@@ -571,7 +570,7 @@ def find_fastest_DDtheta_mocks_bin_refs(autocorr, nthreads, binfile,
         RA2 = np.empty(1)
         DEC2 = np.empty(1)
 
-    if link_in_ra is True:
+    if link_in_ra:
         link_in_dec = True
 
     if not link_in_dec:
@@ -581,12 +580,11 @@ def find_fastest_DDtheta_mocks_bin_refs(autocorr, nthreads, binfile,
               "to enable gridding along DEC or along both RA and DEC."
         raise ValueError(msg)
 
-    if not link_in_ra:
-        if verbose:
-            msg = "INFO: Since ``link_in_ra`` is not set, only gridding in declination " \
-                  "Checking with refinements in declination ranging from [1, {}] and a " \
-                  "maximum of {} bins".format(maxbinref, max_cells_per_dim)
-            print(msg)
+    if verbose and not link_in_ra:
+        msg = "INFO: Since ``link_in_ra`` is not set, only gridding in declination " \
+              "Checking with refinements in declination ranging from [1, {}] and a " \
+              "maximum of {} bins".format(maxbinref, max_cells_per_dim)
+        print(msg)
 
     for ii, (nRA, nDEC) in enumerate(bin_ref_perms):
         total_runtime = 0.0

--- a/Corrfunc/mocks/DDtheta_mocks.py
+++ b/Corrfunc/mocks/DDtheta_mocks.py
@@ -446,7 +446,7 @@ def find_fastest_DDtheta_mocks_bin_refs(autocorr, nthreads, binfile,
     maxbinref: integer (default 3)
         The maximum ``bin refine factor`` to use along each dimension.
 
-        Runtime of module scales as ``maxbinref^3``, so change the value of
+        Runtime of module scales as ``maxbinref^2``, so change the value of
         ``maxbinref`` with caution.
 
         Note that ``max_cells_per_dim`` might need to be increased
@@ -549,14 +549,20 @@ def find_fastest_DDtheta_mocks_bin_refs(autocorr, nthreads, binfile,
     bin_refs = np.arange(1, maxbinref + 1)
     if link_in_ra:
         bin_ref_perms = itertools.product(bin_refs, bin_refs)
+
+        dtype = np.dtype([(bytes_to_native_str(b'nRA'), np.int),
+                          (bytes_to_native_str(b'nDEC'), np.int),
+                          (bytes_to_native_str(b'avg_time'), np.float),
+                          (bytes_to_native_str(b'sigma_time'), np.float)])
+        all_runtimes = np.zeros(maxbinref ** 2, dtype=dtype)
     else:
         bin_ref_perms = [(1, binref) for binref in bin_refs]
 
-    dtype = np.dtype([(bytes_to_native_str(b'nRA'), np.int),
-                      (bytes_to_native_str(b'nDEC'), np.int),
-                      (bytes_to_native_str(b'avg_time'), np.float),
-                      (bytes_to_native_str(b'sigma_time'), np.float)])
-    all_runtimes = np.zeros(maxbinref ** 3, dtype=dtype)
+        dtype = np.dtype([(bytes_to_native_str(b'nRA'), np.int),
+                          (bytes_to_native_str(b'nDEC'), np.int),
+                          (bytes_to_native_str(b'avg_time'), np.float),
+                          (bytes_to_native_str(b'sigma_time'), np.float)])
+        all_runtimes = np.zeros(maxbinref ** 1, dtype=dtype)
     all_runtimes[:] = np.inf
 
     if autocorr == 0:
@@ -590,7 +596,7 @@ def find_fastest_DDtheta_mocks_bin_refs(autocorr, nthreads, binfile,
         total_sqr_runtime = 0.0
 
         for _ in range(nrepeats):
-            t0 = time.time()
+            t0 = time.perf_counter()
             extn_results = DDtheta_mocks_extn(autocorr, nthreads, rbinfile,
                                               RA1, DEC1, RA2, DEC2,
                                               link_in_dec=link_in_dec,
@@ -601,7 +607,7 @@ def find_fastest_DDtheta_mocks_bin_refs(autocorr, nthreads, binfile,
                                               dec_refine_factor=nDEC,
                                               max_cells_per_dim=max_cells_per_dim,
                                               isa=integer_isa)
-            t1 = time.time()
+            t1 = time.perf_counter()
 
             if extn_results is None:
                 msg = "RuntimeError occurred with perms = ({0}, {1})".\

--- a/Corrfunc/theory/wp.py
+++ b/Corrfunc/theory/wp.py
@@ -116,7 +116,7 @@ def find_fastest_wp_bin_refs(boxsize, pimax, nthreads, binfile, X, Y, Z,
 
     runtimes : numpy structured array
 
-        if ``return_runtimes`` is set, then the return value is a tuple
+        Only returned if ``return_runtimes`` is set, then the return value is a tuple
         containing ((nx, ny, nz), runtimes). ``runtimes`` is a ``numpy``
         structured array containing the fields, [``nx``, ``ny``, ``nz``,
         ``avg_runtime``, ``sigma_time``]. Here, ``avg_runtime`` is the

--- a/mocks/DDtheta_mocks/countpairs_theta_mocks_impl.c.src
+++ b/mocks/DDtheta_mocks/countpairs_theta_mocks_impl.c.src
@@ -545,14 +545,19 @@ int countpairs_theta_mocks_DOUBLE(const int64_t ND1, DOUBLE *ra1, DOUBLE *dec1,
         options->bin_refine_factors[1]=numthreads;
     }
 #endif
-    /* Only check the ra and dec bin refine factors (not all 3 bin refs)*/
-    for(int i=0;i<2;i++) {
-        if(options->bin_refine_factors[i] < 1) {
-            fprintf(stderr,"Warning: bin refine factor along axis = %d *must* be >=1. Instead found bin refine factor =%d\n",
-                    i, options->bin_refine_factors[i]);
-            reset_bin_refine_factors(options);
-            break;/* all factors have been reset -> no point continuing with the loop */
-        }
+
+    /* Only check the ra and dec bin refine factors (not all 3 bin refs) */
+    /* As evidenced by the PR #216, the error-message and resetting is not quite right! */
+    if(options->link_in_ra && options->bin_refine_factors[0] < 1) {
+        fprintf(stderr,"Warning: Linking in RA is requested, so the RA-bin refine factor *must* be >=1. Instead found bin refine factor =%d...resetting\n",
+                options->bin_refine_factors[0]);
+        reset_bin_refine_factors(options);
+    }
+
+    if(options->link_in_dec && options->bin_refine_factors[1] < 1) {
+        fprintf(stderr,"Warning: Linking in DEC is requested, so the DEC-bin refine factor *must* be >=1. Instead found bin refine factor =%d...resetting\n",
+                options->bin_refine_factors[1]);
+        reset_bin_refine_factors(options);
     }
 
     if(options->max_cells_per_dim == 0) {


### PR DESCRIPTION
Addresses #97 partially. As the title would suggest, to add the find_fastest_wp_bin_refs() function from [Corrfunc/theory/wp.py#L17](https://github.com/manodeep/Corrfunc/blob/master/Corrfunc/theory/wp.py#L17) to [Corrfunc/mocks/DDtheta_mocks.py](https://github.com/manodeep/Corrfunc/blob/master/Corrfunc/mocks/DDtheta_mocks.py). 