### PR TITLE
Fixing build failure

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -132,7 +132,3 @@ script:
   - make tests CC=$COMPILER
   - make -C docs html
   - if [[ "${DOCTEST}" == "true" ]]; then make -C docs doctest ; fi
-
-branches:
-  only:
-    - master

--- a/.travis.yml
+++ b/.travis.yml
@@ -68,7 +68,7 @@ matrix:
       dist: trusty
       sudo: required
       compiler: gcc
-      env: COMPILER=gcc PYTHON_VERSION=2.7
+      env: COMPILER=gcc PYTHON_VERSION=2.7 DOCTEST=false
       before_install:
         - wget https://repo.continuum.io/miniconda/Miniconda-latest-Linux-x86_64.sh -O miniconda.sh
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,7 @@ addons:
     sources:
       - ubuntu-toolchain-r-test
     packages:
+      - gcc-6
       - gcc-7
 
 
@@ -68,7 +69,7 @@ matrix:
       dist: trusty
       sudo: required
       compiler: gcc
-      env: COMPILER=gcc PYTHON_VERSION=2.7
+      env: COMPILER=gcc-6 PYTHON_VERSION=2.7
       before_install:
         - wget https://repo.continuum.io/miniconda/Miniconda-latest-Linux-x86_64.sh -O miniconda.sh
 
@@ -76,7 +77,7 @@ matrix:
       dist: trusty
       sudo: required
       compiler: gcc
-      env: COMPILER=gcc PYTHON_VERSION=3.5
+      env: COMPILER=gcc-6 PYTHON_VERSION=3.5
       before_install:
         - wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh
 
@@ -84,7 +85,7 @@ matrix:
       dist: xenial
       sudo: required
       compiler: gcc
-      env: COMPILER=gcc PYTHON_VERSION=2.7
+      env: COMPILER=gcc-7 PYTHON_VERSION=2.7
       before_install:
         - wget https://repo.continuum.io/miniconda/Miniconda-latest-Linux-x86_64.sh -O miniconda.sh
 
@@ -92,7 +93,7 @@ matrix:
       dist: xenial
       sudo: required
       compiler: gcc
-      env: COMPILER=gcc PYTHON_VERSION=3.5
+      env: COMPILER=gcc-7 PYTHON_VERSION=3.5
       before_install:
         - wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh
 
@@ -100,7 +101,7 @@ matrix:
       dist: xenial
       sudo: required
       compiler: gcc
-      env: COMPILER=gcc PYTHON_VERSION=3.6
+      env: COMPILER=gcc-7 PYTHON_VERSION=3.6
       before_install:
         - wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh
 
@@ -108,12 +109,11 @@ matrix:
       dist: xenial
       sudo: required
       compiler: gcc
-      env: COMPILER=gcc PYTHON_VERSION=3.7 NUMPY_VERSION=1.16
+      env: COMPILER=gcc-7 PYTHON_VERSION=3.7 NUMPY_VERSION=1.16
       before_install:
         - wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh
 
 install:
-  - if [ "$TRAVIS_OS_NAME" == "linux" ]; then export COMPILER=gcc-7 ; fi
   - bash miniconda.sh -b -p $HOME/miniconda
   - export PATH="$HOME/miniconda/bin:$PATH"
   - conda create -q --yes -n test python=$PYTHON_VERSION

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,8 +19,8 @@ env:
 #     sources:
 #       - ubuntu-toolchain-r-test
 #     packages:
-#       - gcc-6.4
-#       - libgsl0-dev
+#       - gcc-6
+
 
 matrix:
   fast_finish: true
@@ -49,7 +49,6 @@ matrix:
       env: COMPILER=clang FAMILY=clang V='Apple LLVM 7.0.0' PYTHON_VERSION=3.6 DOCTEST=false
       before_install:
         - wget https://repo.continuum.io/miniconda/Miniconda3-latest-MacOSX-x86_64.sh -O miniconda.sh
-
 
     - os: osx
       osx_image: xcode8

--- a/.travis.yml
+++ b/.travis.yml
@@ -113,7 +113,7 @@ matrix:
         - wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh
 
 install:
-  - if [ "$TRAVIS_OS_NAME" = "linux" ]; then eval "CC=gcc-7"        ; fi
+  - if [ "$TRAVIS_OS_NAME" == "linux" ]; then export COMPILER=gcc-7 ; fi
   - bash miniconda.sh -b -p $HOME/miniconda
   - export PATH="$HOME/miniconda/bin:$PATH"
   - conda create -q --yes -n test python=$PYTHON_VERSION

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,13 +14,13 @@ env:
     - DOCTEST=true
     - CORRFUNC_CI=true
 
-addons:
-  apt:
-    sources:
-      - ubuntu-toolchain-r-test
-    packages:
-      - gcc-4.8
-      - libgsl0-dev
+# addons:
+#   apt:
+#     sources:
+#       - ubuntu-toolchain-r-test
+#     packages:
+#       - gcc-6.4
+#       - libgsl0-dev
 
 matrix:
   fast_finish: true
@@ -82,7 +82,23 @@ matrix:
         - wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh
 
     - os: linux
-      dist: trusty
+      dist: xenial
+      sudo: required
+      compiler: gcc
+      env: COMPILER=gcc PYTHON_VERSION=2.7
+      before_install:
+        - wget https://repo.continuum.io/miniconda/Miniconda-latest-Linux-x86_64.sh -O miniconda.sh
+
+    - os: linux
+      dist: xenial
+      sudo: required
+      compiler: gcc
+      env: COMPILER=gcc PYTHON_VERSION=3.5
+      before_install:
+        - wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh
+
+    - os: linux
+      dist: xenial
       sudo: required
       compiler: gcc
       env: COMPILER=gcc PYTHON_VERSION=3.6
@@ -90,7 +106,7 @@ matrix:
         - wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh
 
     - os: linux
-      dist: trusty
+      dist: xenial
       sudo: required
       compiler: gcc
       env: COMPILER=gcc PYTHON_VERSION=3.7 NUMPY_VERSION=1.16

--- a/.travis.yml
+++ b/.travis.yml
@@ -123,6 +123,9 @@ install:
   - python -m pip install --upgrade pip
   - python -m pip install --ignore-installed certifi --upgrade
   - python -m pip install sphinx>=1.8
+  - export CC=$COMPILER
+  - which $COMPILER
+  - $COMPILER --version
   - make -r CC=$COMPILER
   - make install CC=$COMPILER
   - python -m pip install -e .

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,12 +14,12 @@ env:
     - DOCTEST=true
     - CORRFUNC_CI=true
 
-# addons:
-#   apt:
-#     sources:
-#       - ubuntu-toolchain-r-test
-#     packages:
-#       - gcc-6
+addons:
+  apt:
+    sources:
+      - ubuntu-toolchain-r-test
+    packages:
+      - gcc-7
 
 
 matrix:
@@ -113,6 +113,7 @@ matrix:
         - wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh
 
 install:
+  - if [ "$TRAVIS_OS_NAME" = "linux" ]; then eval "CC=gcc-7"        ; fi
   - bash miniconda.sh -b -p $HOME/miniconda
   - export PATH="$HOME/miniconda/bin:$PATH"
   - conda create -q --yes -n test python=$PYTHON_VERSION

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,6 @@ addons:
     sources:
       - ubuntu-toolchain-r-test
     packages:
-      - gcc-6
       - gcc-7
 
 
@@ -69,7 +68,7 @@ matrix:
       dist: trusty
       sudo: required
       compiler: gcc
-      env: COMPILER=gcc-6 PYTHON_VERSION=2.7
+      env: COMPILER=gcc PYTHON_VERSION=2.7
       before_install:
         - wget https://repo.continuum.io/miniconda/Miniconda-latest-Linux-x86_64.sh -O miniconda.sh
 
@@ -77,7 +76,7 @@ matrix:
       dist: trusty
       sudo: required
       compiler: gcc
-      env: COMPILER=gcc-6 PYTHON_VERSION=3.5
+      env: COMPILER=gcc PYTHON_VERSION=3.5
       before_install:
         - wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -19,6 +19,7 @@ Enhancements
 ------------
 - A new helper routine to find the combination of (RA, DEC) refinements that produces fastest runtime in ``DDtheta_mocks`` [#216]
 - Further testing via GitHub Actions [#220]
+- Added Ubuntu-Xenial on Travis [#222]
 
 Bug fixes
 ----------

--- a/common.mk
+++ b/common.mk
@@ -177,7 +177,7 @@ ifeq ($(DO_CHECKS), 1)
 
   # Add the -Werror flag if running on some continuous integration provider
   ifeq ($(CORRFUNC_CI), true)
-    CFLAGS += -Werror -Wno-unknown-warning-option -Wimplicit-fallthrough=1
+    CFLAGS += -Werror -Wimplicit-fallthrough=1 -Wno-unknown-warning-option
   endif
 
   GSL_FOUND := $(shell gsl-config --version 2>/dev/null)

--- a/common.mk
+++ b/common.mk
@@ -177,7 +177,12 @@ ifeq ($(DO_CHECKS), 1)
 
   # Add the -Werror flag if running on some continuous integration provider
   ifeq ($(CORRFUNC_CI), true)
-    CFLAGS += -Werror -Wimplicit-fallthrough=1 -Wno-unknown-warning-option
+    CFLAGS += -Werror -Wno-unknown-warning-option
+  endif
+
+  # Add the implicit-fallthrough option *if not on* TRAVIS
+  ifneq ($(TRAVIS), true)
+   -CFLAGS += -Wimplicit-fallthrough=1
   endif
 
   GSL_FOUND := $(shell gsl-config --version 2>/dev/null)


### PR DESCRIPTION
Apparently TRAVIS was only running on the master branch

The build failures were due to `-Werror`, not anything code related. However, still good that we now have the additional testing through GitHub actions via #220 

The way the tests are divided now is that TRAVIS is checking old linux + compiler (i.e., sort of legacy systems) while GitHub Actions is testing more modern distros + compilers + python + numpy. 