### PR TITLE
Fix Python reference leak to results struct

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -15,7 +15,7 @@ New features
 
 Bug fixes
 ---------
-- Fix Python reference leak to results struct [#227]
+- Fix Python reference leak to results struct [#229]
 
 
 2.3.4 (2019-07-21)

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,6 +10,14 @@ New features
 - conda installable package
 - GPU version
 
+2.3.5 (upcoming)
+==================
+
+Bug fixes
+---------
+- Fix Python reference leak to results struct [#227]
+
+
 2.3.4 (2019-07-21)
 ==================
 This is a bug-fix release and contains general code quality improvements.

--- a/mocks/python_bindings/_countpairs_mocks.c
+++ b/mocks/python_bindings/_countpairs_mocks.c
@@ -1403,7 +1403,10 @@ static PyObject *countpairs_countpairs_rp_pi_mocks(PyObject *self, PyObject *arg
         rlow=results.rupp[i];
     }
     free_results_mocks(&results);
-    return Py_BuildValue("(Od)", ret, c_api_time);
+
+    PyObject *rettuple = Py_BuildValue("(Od)", ret, c_api_time);
+    Py_DECREF(ret);  // transfer reference ownership to the tuple
+    return rettuple;
 }
 
 static PyObject *countpairs_countpairs_s_mu_mocks(PyObject *self, PyObject *args, PyObject *kwargs)
@@ -1726,7 +1729,10 @@ static PyObject *countpairs_countpairs_s_mu_mocks(PyObject *self, PyObject *args
         rlow=results.supp[i];
     }
     free_results_mocks_s_mu(&results);
-    return Py_BuildValue("(Od)", ret, c_api_time);
+
+    PyObject *rettuple = Py_BuildValue("(Od)", ret, c_api_time);
+    Py_DECREF(ret);  // transfer reference ownership to the tuple
+    return rettuple;
 }
 
 static PyObject *countpairs_countpairs_theta_mocks(PyObject *self, PyObject *args, PyObject *kwargs)
@@ -2015,7 +2021,10 @@ static PyObject *countpairs_countpairs_theta_mocks(PyObject *self, PyObject *arg
         rlow=results.theta_upp[i];
     }
     free_results_countpairs_theta(&results);
-    return Py_BuildValue("(Od)", ret, c_api_time);
+
+    PyObject *rettuple = Py_BuildValue("(Od)", ret, c_api_time);
+    Py_DECREF(ret);  // transfer reference ownership to the tuple
+    return rettuple;
 }
 
 
@@ -2248,5 +2257,7 @@ static PyObject *countpairs_countspheres_vpf_mocks(PyObject *self, PyObject *arg
     }
     free_results_countspheres_mocks(&results);
 
-    return Py_BuildValue("(Od)", ret, c_api_time);
+    PyObject *rettuple = Py_BuildValue("(Od)", ret, c_api_time);
+    Py_DECREF(ret);  // transfer reference ownership to the tuple
+    return rettuple;
 }

--- a/theory/python_bindings/_countpairs.c
+++ b/theory/python_bindings/_countpairs.c
@@ -1722,7 +1722,9 @@ static PyObject *countpairs_countpairs_rp_pi(PyObject *self, PyObject *args, PyO
     }
     free_results_rp_pi(&results);
 
-    return Py_BuildValue("(Od)", ret, c_api_time);
+    PyObject *rettuple = Py_BuildValue("(Od)", ret, c_api_time);
+    Py_DECREF(ret);  // transfer reference ownership to the tuple
+    return rettuple;
 }
 
 static PyObject *countpairs_countpairs_wp(PyObject *self, PyObject *args, PyObject *kwargs)

--- a/theory/python_bindings/_countpairs.c
+++ b/theory/python_bindings/_countpairs.c
@@ -1424,7 +1424,10 @@ static PyObject *countpairs_countpairs(PyObject *self, PyObject *args, PyObject 
     }
 
     free_results(&results);
-    return Py_BuildValue("(Od)", ret, c_api_time);
+
+    PyObject *rettuple = Py_BuildValue("(Od)", ret, c_api_time);
+    Py_DECREF(ret);  // transfer reference ownership to the tuple
+    return rettuple;
 }
 
 
@@ -1965,7 +1968,10 @@ static PyObject *countpairs_countpairs_wp(PyObject *self, PyObject *args, PyObje
         }
         free_cell_timings(&options);
     }
-    return Py_BuildValue("(OdO)", ret, c_api_time, c_cell_time);
+    PyObject *rettuple = Py_BuildValue("(OdO)", ret, c_api_time, c_cell_time);
+    Py_DECREF(ret);  // transfer reference ownership to the tuple
+    Py_DECREF(c_cell_time);
+    return rettuple;
 }
 
 
@@ -2187,7 +2193,9 @@ static PyObject *countpairs_countpairs_xi(PyObject *self, PyObject *args, PyObje
     }
     free_results_xi(&results);
 
-    return Py_BuildValue("(Od)", ret, c_api_time);
+    PyObject *rettuple = Py_BuildValue("(Od)", ret, c_api_time);
+    Py_DECREF(ret);  // transfer reference ownership to the tuple
+    return rettuple;
 }
 
 
@@ -2491,7 +2499,9 @@ static PyObject *countpairs_countpairs_s_mu(PyObject *self, PyObject *args, PyOb
     }
     free_results_s_mu(&results);
 
-    return Py_BuildValue("(Od)", ret, c_api_time);
+    PyObject *rettuple = Py_BuildValue("(Od)", ret, c_api_time);
+    Py_DECREF(ret);  // transfer reference ownership to the tuple
+    return rettuple;
 }
 
 
@@ -2663,5 +2673,8 @@ static PyObject *countpairs_countspheres_vpf(PyObject *self, PyObject *args, PyO
     }
 
     free_results_countspheres(&results);
-    return Py_BuildValue("(Od)", ret, c_api_time);
+
+    PyObject *rettuple = Py_BuildValue("(Od)", ret, c_api_time);
+    Py_DECREF(ret);  // transfer reference ownership to the tuple
+    return rettuple;
 }


### PR DESCRIPTION
From #227, I think we have a Python reference leak to the results structure.  Specifically, I think the following pattern results in a leak:
```C
PyObject *ret = PyList_New(0);//create an empty list
...
return Py_BuildValue("(Od)", ret, c_api_time);
```
`PyBuildValue` adds a ref, but the `PyList_New` reference is never decremented.  This PR decrements the ref count after building the tuple, before the return.

Once we verify the fix, I'll port it to the other modules.