### PR TITLE
Removed independent volume check in vpf.py

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -15,7 +15,7 @@ New features
 
 Enhancements
 ------------
-- Removed the unnecessary check in ``theory.vpf`` that required the volume inhabited by the dropped spheres be less than the volume of the sample [#238]
+- In the theoretical VPF calculation (``theory.vpf``), the total volume of the random spheres can now exceed the volume of the sample  [#238]
 
 Bug fixes
 ---------

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -15,7 +15,7 @@ New features
 
 Enhancements
 ------------
-- Removed the unnecessary check in ``theory.vpf`` that required the volume inhabited by the dropped spheres be less than the volume of the sample [#239]
+- Removed the unnecessary check in ``theory.vpf`` that required the volume inhabited by the dropped spheres be less than the volume of the sample [#238]
 
 Bug fixes
 ---------

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -13,6 +13,10 @@ New features
 2.4.0 (upcoming)
 ==================
 
+Enhancements
+------------
+- Removed the unnecessary check in ``theory.vpf`` that required the volume inhabited by the dropped spheres be less than the volume of the sample [#239]
+
 Bug fixes
 ---------
 - Fix Python reference leak to results struct [#229]

--- a/Corrfunc/theory/vpf.py
+++ b/Corrfunc/theory/vpf.py
@@ -203,15 +203,6 @@ def vpf(rmax, nbins, nspheres, numpN, seed,
                  (max(Y) - min(Y)) * \
                  (max(Z) - min(Z))
 
-    volume_sphere = 4. / 3. * pi * rmax * rmax * rmax
-    if nspheres * volume_sphere > volume:
-        msg = "There are not as many independent volumes in the "\
-              "requested particle distribution. Num. spheres = {0} "\
-              "rmax = {1} => effective volume = {2}.\nVolume of particles ="\
-              "{3}. Reduce rmax or Nspheres"\
-              .format(nspheres, rmax, nspheres * volume_sphere, volume)
-        raise ValueError(msg)
-
     # Ensure all input arrays are native endian
     X, Y, Z = [convert_to_native_endian(arr, warn=True)
                for arr in [X, Y, Z]]

--- a/Corrfunc/theory/vpf.py
+++ b/Corrfunc/theory/vpf.py
@@ -196,13 +196,6 @@ def vpf(rmax, nbins, nspheres, numpN, seed,
         msg = "Number of counts-in-cells wanted must be at least 1"
         raise ValueError(msg)
 
-    if boxsize > 0.0:
-        volume = boxsize * boxsize * boxsize
-    else:
-        volume = (max(X) - min(X)) * \
-                 (max(Y) - min(Y)) * \
-                 (max(Z) - min(Z))
-
     # Ensure all input arrays are native endian
     X, Y, Z = [convert_to_native_endian(arr, warn=True)
                for arr in [X, Y, Z]]


### PR DESCRIPTION
Following the discussion in issue #237 and after conversations with LGarrison, I've completely removed the check that confirmed that the volume inhabited by the dropped spheres was less than the volume of the sample. This check was unnecessary for the VPF to run, and actively discouraged the oversampling of the sample volume with test spheres that one needs to precisely measure the VPF at a given radius.