### PR TITLE
Parallel gridlink

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -13,6 +13,10 @@ New features
 2.4.0 (upcoming)
 ==================
 
+Enhancements
+------------
+- Gridlink (the binning of particles into cells) now uses a parallel algorithm for the theory module [#239]
+
 Bug fixes
 ---------
 - Fix Python reference leak to results struct [#229]

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,7 +10,7 @@ New features
 - conda installable package
 - GPU version
 
-2.3.5 (upcoming)
+2.4.0 (upcoming)
 ==================
 
 Bug fixes

--- a/theory/tests/Makefile
+++ b/theory/tests/Makefile
@@ -113,5 +113,5 @@ xi: test_periodic
 
 celna clena celan: clean
 clean:
-	$(RM) $(targets) $(OBJS1) $(OBJS2)
+	$(RM) $(TARGETS) $(OBJS1) $(OBJS2)
 	$(RM) -R *.dSYM

--- a/utils/gridlink_impl.c.src
+++ b/utils/gridlink_impl.c.src
@@ -98,14 +98,13 @@ cellarray_DOUBLE * gridlink_DOUBLE(const int64_t NPART,
     int w_alloc_status = 0;
     int num_weights = (WEIGHTS == NULL) ? 0 : WEIGHTS->num_weights;
     
-    int64_t *cellstarts = NULL;
-    int64_t *original_indices =  NULL;
+    int64_t *cellstarts = cellstarts = (int64_t *) my_malloc(sizeof(int64_t), totncells);
     int64_t *all_cell_indices = (int64_t *) my_malloc(sizeof(*all_cell_indices), NPART);
+    int64_t *original_indices =  NULL;
     if(options->copy_particles) {
         realX = (DOUBLE *) my_malloc(sizeof(DOUBLE), NPART);
         realY = (DOUBLE *) my_malloc(sizeof(DOUBLE), NPART);
         realZ = (DOUBLE *) my_malloc(sizeof(DOUBLE), NPART);
-        cellstarts = (int64_t *) my_malloc(sizeof(int64_t), totncells);
         
         for(int w = 0; w < num_weights; w++){
             realW[w] = (DOUBLE *) my_malloc(sizeof(DOUBLE), NPART);
@@ -229,7 +228,7 @@ cellarray_DOUBLE * gridlink_DOUBLE(const int64_t NPART,
             lattice[icell].original_index = original_indices + cellstarts[icell];
                 
             // The lattice will point into the original arrays
-            lattice[icell].z = X + cellstarts[icell];
+            lattice[icell].x = X + cellstarts[icell];
             lattice[icell].y = Y + cellstarts[icell];
             lattice[icell].z = Z + cellstarts[icell];
 
@@ -315,7 +314,7 @@ cellarray_DOUBLE * gridlink_DOUBLE(const int64_t NPART,
             SGLIB_ARRAY_ELEMENTS_EXCHANGER(DOUBLE, Z, i, j);            \
             SGLIB_ARRAY_ELEMENTS_EXCHANGER(int64_t, original_indices, i, j); \
             SGLIB_ARRAY_ELEMENTS_EXCHANGER(int64_t, all_cell_indices, i, j); \
-            for(int w = 0; w < WEIGHTS->num_weights; w++) {             \
+            for(int w = 0; w < num_weights; w++) {             \
                 SGLIB_ARRAY_ELEMENTS_EXCHANGER(DOUBLE, ((DOUBLE *) WEIGHTS->weights[w]), i, j); \
             }                                                           \
         }
@@ -339,9 +338,7 @@ cellarray_DOUBLE * gridlink_DOUBLE(const int64_t NPART,
                 SGLIB_ARRAY_QUICK_SORT(int64_t, all_cell_indices, NPART, SGLIB_NUMERIC_COMPARATOR, MULTIPLE_ARRAY_EXCHANGER);
             }
         }
-
-        //Now the particles are sorted contiguously according to their respective cellindex
-        //We need to fix up the x/y/z pointers at the beginning of each cell to point to the right places
+        
 #undef MULTIPLE_ARRAY_EXCHANGER
     }//end of options->copy_particles == 0
     

--- a/utils/gridlink_impl.c.src
+++ b/utils/gridlink_impl.c.src
@@ -118,7 +118,7 @@ cellarray_DOUBLE * gridlink_DOUBLE(const int64_t NPART,
        (options->copy_particles && (realX == NULL || realY == NULL || realZ == NULL || cellstarts == NULL || w_alloc_status != 0))){
 
         free(lattice);free(realX);free(realY);free(realZ);free(all_cell_indices);free(original_indices);
-        for(int w = 0; w < MAX_NUM_WEIGHTS; w++){
+        for(int w = 0; w < num_weights; w++){
             free(realW[w]);
         }
         fprintf(stderr,"Error: In %s> Could not allocate memory for creating the lattice and associated arrays\n", __FUNCTION__);
@@ -157,11 +157,11 @@ cellarray_DOUBLE * gridlink_DOUBLE(const int64_t NPART,
     // Now determine the number of particles per cell so each cell knows its global starting index
     // This information is used for both the copy and in-place versions
 #if defined(_OPENMP)
-    int max_nthreads = omp_get_max_threads();
+    int nthreads = omp_get_max_threads();  // this is the upper bound, we will find the actual value (usually the same) below
 #else
-    int max_nthreads = 1;
+    int nthreads = 1;
 #endif
-    int64_t *cell_occupation[max_nthreads];
+    int64_t *cell_occupation[nthreads];
 
 #if defined(_OPENMP)
     #pragma omp parallel
@@ -169,6 +169,7 @@ cellarray_DOUBLE * gridlink_DOUBLE(const int64_t NPART,
     {
         #if defined(_OPENMP)
         int tid = omp_get_thread_num();
+        nthreads = omp_get_num_threads();  // reduce to actual number of threads, will be the same in almost all cases
         #else
         int tid = 0;
         #endif
@@ -186,7 +187,7 @@ cellarray_DOUBLE * gridlink_DOUBLE(const int64_t NPART,
     #pragma omp parallel for schedule(static)
 #endif
     for(int64_t c = 0; c < totncells; c++){
-        for(int t = 1; t < max_nthreads; t++){
+        for(int t = 1; t < nthreads; t++){
             cell_occupation[0][c] += cell_occupation[t][c];
         }
     }
@@ -250,10 +251,8 @@ cellarray_DOUBLE * gridlink_DOUBLE(const int64_t NPART,
     {
         #if defined(_OPENMP)
         int tid = omp_get_thread_num();
-        int nthreads = omp_get_num_threads();
         #else
         int tid = 0;
-        int nthreads = 1;
         #endif
         int64_t cstart = totncells*tid/nthreads;
         int64_t cend = totncells*(tid+1)/nthreads;
@@ -295,7 +294,7 @@ cellarray_DOUBLE * gridlink_DOUBLE(const int64_t NPART,
                 __FUNCTION__, cell_occupation[0][c], lattice[c].nelements);
     }
     
-    for(int t = 0; t < max_nthreads; t++)
+    for(int t = 0; t < nthreads; t++)
         free(cell_occupation[t]);
 
     if(!options->copy_particles) {
@@ -363,7 +362,7 @@ cellarray_DOUBLE * gridlink_DOUBLE(const int64_t NPART,
                 SGLIB_ARRAY_ELEMENTS_EXCHANGER(DOUBLE, first->y, i, j); \
                 SGLIB_ARRAY_ELEMENTS_EXCHANGER(DOUBLE, first->z, i, j); \
                 /* original_index is not used if copying the particles */ \
-                if(!options->copy_particles) { \
+                if(options->copy_particles == 0) { \
                     SGLIB_ARRAY_ELEMENTS_EXCHANGER(int64_t, first->original_index, i, j); \
                 } \
                 for(int w = 0; w < first->weights.num_weights; w++){    \

--- a/utils/gridlink_impl.c.src
+++ b/utils/gridlink_impl.c.src
@@ -131,6 +131,10 @@ cellarray_DOUBLE * gridlink_DOUBLE(const int64_t NPART,
     const DOUBLE zinv=1.0/zbinsize;
 
     // First pass over the particles: compute cell indices
+    int64_t out_of_bounds = 0;
+#if defined(_OPENMP)
+    #pragma omp parallel for schedule(static) reduction(+:out_of_bounds)
+#endif
     for (int64_t i=0;i<NPART;i++)  {
         int ix=(int)((X[i]-xmin)*xinv) ;
         int iy=(int)((Y[i]-ymin)*yinv) ;
@@ -139,57 +143,60 @@ cellarray_DOUBLE * gridlink_DOUBLE(const int64_t NPART,
         if (ix>nmesh_x-1)  ix--;    /* this shouldn't happen, but . . . */
         if (iy>nmesh_y-1)  iy--;
         if (iz>nmesh_z-1)  iz--;
-        
-        XRETURN(X[i] >= xmin && X[i] <= xmax, NULL,
-               "x[%"PRId64"] = %"REAL_FORMAT" must be within [%"REAL_FORMAT",%"REAL_FORMAT"]\n",
-                i, X[i], xmin, xmax);
-        XRETURN(Y[i] >= ymin && Y[i] <= ymax, NULL,
-               "y[%"PRId64"] = %"REAL_FORMAT" must be within [%"REAL_FORMAT",%"REAL_FORMAT"]\n",
-               i, Y[i], ymin, ymax);
-        XRETURN(Z[i] >= zmin && Z[i] <= zmax, NULL,
-               "z[%"PRId64"] = %"REAL_FORMAT" must be within [%"REAL_FORMAT",%"REAL_FORMAT"]\n",
-               i, Z[i], zmin, zmax);
-
-        XRETURN(ix >= 0 && ix < nmesh_x, NULL, "ix=%d must be within [0,%d)\n", ix, nmesh_x);
-        XRETURN(iy >= 0 && iy < nmesh_y, NULL, "iy=%d must be within [0,%d)\n", iy, nmesh_y);
-        XRETURN(iz >= 0 && iz < nmesh_z, NULL, "iz=%d must be within [0,%d)\n", iz, nmesh_z);
+    
+        out_of_bounds += ix < 0 || ix >= nmesh_x || iy < 0 || iy >= nmesh_y || iz < 0 || iz >= nmesh_z;
 
         const int64_t icell = CONVERT_3D_INDEX_TO_LINEAR(ix, iy, iz, nmesh_x, nmesh_y, nmesh_z);
-        assert(icell < totncells);
         all_cell_indices[i] = icell;
         if(!options->copy_particles){
             original_indices[i] = i;
         }
     }
     
+    XRETURN(out_of_bounds == 0, NULL, "%"PRId64" particles are out of bounds. Check periodic wrapping?\n", out_of_bounds);
+    
     // Now determine the number of particles per cell so each cell knows its global starting index
     // This information is used for both the copy and in-place versions
+#if defined(_OPENMP)
     int Nthread = omp_get_max_threads();
+#else
+    int Nthread = 1;
+#endif
     int64_t *cell_occupation[Nthread];
-    //#pragma omp parallel for schedule(static)
+
+#if defined(_OPENMP)
+    #pragma omp parallel for schedule(static)
+#endif
     for(int t = 0; t < Nthread; t++){
         cell_occupation[t] = my_calloc(totncells, sizeof(int64_t));
     }
-    //#pragma omp parallel for schedule(static)
+#if defined(_OPENMP)
+    #pragma omp parallel for schedule(static)
+#endif
     for(int64_t i = 0; i < NPART; i++){
-        cell_occupation[omp_get_thread_num()][all_cell_indices[i]]++;
+        #if defined(_OPENMP)
+        int tid = omp_get_thread_num();
+        #else
+        int tid = 0;
+        #endif
+        cell_occupation[tid][all_cell_indices[i]]++;
     }
-    //#pragma omp parallel for schedule(static)
+#if defined(_OPENMP)
+    #pragma omp parallel for schedule(static)
+#endif
     for(int64_t c = 0; c < totncells; c++){
         for(int t = 1; t < Nthread; t++){
-            assert(cell_occupation[t][c] == 0);
             cell_occupation[0][c] += cell_occupation[t][c];
         }
     }
 
-    // Cumulative sum of the cell histogram
-    cellstarts[0] = 0;
-    for(int64_t c = 1; c < totncells; c++){
-        cellstarts[c] = cell_occupation[0][c-1] + cellstarts[c-1];
-    }
+    // Fill cellstarts with the cumulative sum of the cell histogram
+    parallel_cumsum(cell_occupation[0], totncells, cellstarts);
 
     // Initialize the lattice
-    //#pragma omp parallel for schedule(static)
+#if defined(_OPENMP)
+    #pragma omp parallel for schedule(static)
+#endif
     for (int64_t icell=0;icell<totncells;icell++) {
         lattice[icell].nelements = 0;
         lattice[icell].owns_memory = 0;
@@ -235,31 +242,47 @@ cellarray_DOUBLE * gridlink_DOUBLE(const int64_t NPART,
     
     free(cellstarts);
 
-    // Second loop over particles: having computed the starts of each cell, fill the cells
-    for (int64_t i=0;i<NPART;i++) {
-        const int64_t icell = all_cell_indices[i];
-        if(options->copy_particles) {
-            const int64_t ipos = lattice[icell].nelements;
-            lattice[icell].x[ipos] = X[i];
-            lattice[icell].y[ipos] = Y[i];
-            lattice[icell].z[ipos] = Z[i];
-            for(int w = 0; w < num_weights; w++){
-                lattice[icell].weights.weights[w][ipos] = ((DOUBLE *) WEIGHTS->weights[w])[i];
+    // Each thread is going to loop over all particles, but only process those in its cell domain
+#if defined(_OPENMP)
+    #pragma omp parallel
+#endif
+    {
+        #if defined(_OPENMP)
+        int tid = omp_get_thread_num();
+        #else
+        int tid = 0;
+        #endif
+        int64_t cstart = totncells*tid/Nthread;
+        int64_t cend = totncells*(tid+1)/Nthread;
+        // Second loop over particles: having computed the starts of each cell, fill the cells
+        for (int64_t i=0;i<NPART;i++) {
+            const int64_t icell = all_cell_indices[i];
+            if(icell < cstart || icell >= cend){
+                continue;
             }
+            if(options->copy_particles) {
+                const int64_t ipos = lattice[icell].nelements;
+                lattice[icell].x[ipos] = X[i];
+                lattice[icell].y[ipos] = Y[i];
+                lattice[icell].z[ipos] = Z[i];
+                for(int w = 0; w < num_weights; w++){
+                    lattice[icell].weights.weights[w][ipos] = ((DOUBLE *) WEIGHTS->weights[w])[i];
+                }
+            }
+
+            // Store the particle bounds
+            // Needs to be done for both the copy and in-place versions
+            lattice[icell].xbounds[0] = X[i] < lattice[icell].xbounds[0] ? X[i]:lattice[icell].xbounds[0];
+            lattice[icell].ybounds[0] = Y[i] < lattice[icell].ybounds[0] ? Y[i]:lattice[icell].ybounds[0];
+            lattice[icell].zbounds[0] = Z[i] < lattice[icell].zbounds[0] ? Z[i]:lattice[icell].zbounds[0];
+
+            lattice[icell].xbounds[1] = X[i] > lattice[icell].xbounds[1] ? X[i]:lattice[icell].xbounds[1];
+            lattice[icell].ybounds[1] = Y[i] > lattice[icell].ybounds[1] ? Y[i]:lattice[icell].ybounds[1];
+            lattice[icell].zbounds[1] = Z[i] > lattice[icell].zbounds[1] ? Z[i]:lattice[icell].zbounds[1];
+
+            lattice[icell].nelements++;
         }
-
-        // Store the particle bounds
-        // Needs to be done for both the copy and in-place versions
-        lattice[icell].xbounds[0] = X[i] < lattice[icell].xbounds[0] ? X[i]:lattice[icell].xbounds[0];
-        lattice[icell].ybounds[0] = Y[i] < lattice[icell].ybounds[0] ? Y[i]:lattice[icell].ybounds[0];
-        lattice[icell].zbounds[0] = Z[i] < lattice[icell].zbounds[0] ? Z[i]:lattice[icell].zbounds[0];
-
-        lattice[icell].xbounds[1] = X[i] > lattice[icell].xbounds[1] ? X[i]:lattice[icell].xbounds[1];
-        lattice[icell].ybounds[1] = Y[i] > lattice[icell].ybounds[1] ? Y[i]:lattice[icell].ybounds[1];
-        lattice[icell].zbounds[1] = Z[i] > lattice[icell].zbounds[1] ? Z[i]:lattice[icell].zbounds[1];
-
-        lattice[icell].nelements++;
-    }
+    }  // end parallel region
     
     for(int64_t c = 0; c < totncells; c++){
         XRETURN(lattice[c].nelements == cell_occupation[0][c], NULL,

--- a/utils/gridlink_impl.c.src
+++ b/utils/gridlink_impl.c.src
@@ -25,8 +25,6 @@
 #include <omp.h>
 #endif
 
-#define MEMORY_INCREASE_FAC   1.2
-
 #ifndef CONVERT_3D_INDEX_TO_LINEAR
 #define CONVERT_3D_INDEX_TO_LINEAR(ix, iy, iz, nx, ny, nz)           {ix*ny*nz + iy*nz + iz}
 #endif
@@ -45,7 +43,6 @@ void free_cellarray_DOUBLE(cellarray_DOUBLE *lattice, const int64_t totncells)
                 free(lattice[i].x);
                 free(lattice[i].y);
                 free(lattice[i].z);
-                free(lattice[i].original_index);
                 for(int w = 0; w < lattice[i].weights.num_weights; w++){
                     free(lattice[i].weights.weights[w]);
                 }
@@ -91,86 +88,49 @@ cellarray_DOUBLE * gridlink_DOUBLE(const int64_t NPART,
 
     const int64_t totncells = (int64_t) nmesh_x * (int64_t) nmesh_y * (int64_t) nmesh_z;
 
-    const DOUBLE xdiff = (options->periodic && options->boxsize > 0) ? options->boxsize:xmax-xmin;
-    const DOUBLE ydiff = (options->periodic && options->boxsize > 0) ? options->boxsize:ymax-ymin;
-    const DOUBLE zdiff = (options->periodic && options->boxsize > 0) ? options->boxsize:zmax-zmin;
-
-    const DOUBLE cell_volume = xbinsize * ybinsize * zbinsize;
-    const DOUBLE box_volume = xdiff * ydiff * zdiff;
-    int64_t expected_n=(int64_t)(NPART * cell_volume/box_volume * MEMORY_INCREASE_FAC);
-    expected_n=expected_n < 2 ? 2:expected_n;
-
     if(options->verbose) {
       fprintf(stderr,"In %s> Running with [nmesh_x, nmesh_y, nmesh_z]  = %d,%d,%d. ",__FUNCTION__,nmesh_x,nmesh_y,nmesh_z);
     }
 
     cellarray_DOUBLE *lattice  = (cellarray_DOUBLE *) my_malloc(sizeof(*lattice), totncells);
-    int64_t *all_cell_indices = NULL;
+    DOUBLE *realX = NULL, *realY = NULL, *realZ = NULL;  // The actual allocations backing the lattice
+    DOUBLE *realW[MAX_NUM_WEIGHTS] = {NULL};  // This initializes the whole array to NULL
+    int w_alloc_status = 0;
+    int num_weights = (WEIGHTS == NULL) ? 0 : WEIGHTS->num_weights;
+    
+    int64_t *cellstarts = NULL;
     int64_t *original_indices =  NULL;
-    int64_t *nallocated = NULL;//to keep track of how many particles have been allocated per cell (only when creating a copy of particle positions)
+    int64_t *all_cell_indices = (int64_t *) my_malloc(sizeof(*all_cell_indices), NPART);
     if(options->copy_particles) {
-        nallocated = (int64_t *) my_malloc(sizeof(*nallocated), totncells);
+        realX = (DOUBLE *) my_malloc(sizeof(DOUBLE), NPART);
+        realY = (DOUBLE *) my_malloc(sizeof(DOUBLE), NPART);
+        realZ = (DOUBLE *) my_malloc(sizeof(DOUBLE), NPART);
+        cellstarts = (int64_t *) my_malloc(sizeof(int64_t), totncells);
+        
+        for(int w = 0; w < num_weights; w++){
+            realW[w] = (DOUBLE *) my_malloc(sizeof(DOUBLE), NPART);
+            w_alloc_status |= realW[w] == NULL;
+        }
     } else {
-        all_cell_indices = (int64_t *) my_malloc(sizeof(*all_cell_indices), NPART);
         original_indices = (int64_t *) my_malloc(sizeof(*original_indices), NPART);
     }
-    if(lattice == NULL ||
-       (options->copy_particles == 0 && all_cell_indices == NULL) ||
+    if(lattice == NULL || all_cell_indices == NULL ||
        (options->copy_particles == 0 && original_indices == NULL) ||
-       (options->copy_particles && nallocated == NULL)) {
+       (options->copy_particles && (realX == NULL || realY == NULL || realZ == NULL || cellstarts == NULL || w_alloc_status != 0))){
 
-        free(lattice);free(nallocated);free(all_cell_indices);free(original_indices);
+        free(lattice);free(realX);free(realY);free(realZ);free(all_cell_indices);free(original_indices);
+        for(int w = 0; w < MAX_NUM_WEIGHTS; w++){
+            free(realW[w]);
+        }
         fprintf(stderr,"Error: In %s> Could not allocate memory for creating the lattice and associated arrays\n", __FUNCTION__);
         return NULL;
     }
-
-    for (int64_t icell=0;icell<totncells;icell++) {
-        lattice[icell].nelements = 0;
-        lattice[icell].owns_memory = 0;
-        lattice[icell].weights.num_weights = (WEIGHTS == NULL) ? 0 : WEIGHTS->num_weights;
-        lattice[icell].xbounds[0] = MAX_POSITIVE_FLOAT;
-        lattice[icell].xbounds[1] = -MAX_POSITIVE_FLOAT;
-        lattice[icell].ybounds[0] = MAX_POSITIVE_FLOAT;
-        lattice[icell].ybounds[1] = -MAX_POSITIVE_FLOAT;
-        lattice[icell].zbounds[0] = MAX_POSITIVE_FLOAT;
-        lattice[icell].zbounds[1] = -MAX_POSITIVE_FLOAT;
-
-        if(options->copy_particles) {
-            lattice[icell].owns_memory = 1;
-            lattice[icell].original_index = my_malloc(sizeof(lattice[icell].original_index[0]), expected_n);
-            const size_t memsize=sizeof(DOUBLE);
-            lattice[icell].x = my_malloc(memsize,expected_n);//This allocates extra and is wasteful
-            lattice[icell].y = my_malloc(memsize,expected_n);//This allocates extra and is wasteful
-            lattice[icell].z = my_malloc(memsize,expected_n);//This allocates extra and is wasteful
-
-            // Now do the same for the weights
-            int w_alloc_status = EXIT_SUCCESS;
-            for(int w = 0; w < lattice[icell].weights.num_weights; w++){
-                lattice[icell].weights.weights[w] = (DOUBLE *) my_malloc(memsize, expected_n);
-                if(lattice[icell].weights.weights[w] == NULL){
-                    w_alloc_status = EXIT_FAILURE;
-                }
-            }
-
-            if(lattice[icell].x == NULL || lattice[icell].y == NULL || lattice[icell].z == NULL ||
-               lattice[icell].original_index == NULL || w_alloc_status == EXIT_FAILURE) {
-                for(int64_t j=icell;j>=0;j--) {
-                    free(lattice[j].x);free(lattice[j].y);free(lattice[j].z);free(lattice[j].original_index);
-                    for(int w = 0; w < lattice[icell].weights.num_weights; w++){
-                        free(lattice[icell].weights.weights[w]);
-                    }
-                }
-                free(nallocated);free(lattice);
-                return NULL;
-            }
-            nallocated[icell] = expected_n;
-        }//if condition when creating a copy of the particle positions
-    }//end of loop over totncells
 
     const DOUBLE xinv=1.0/xbinsize;
     const DOUBLE yinv=1.0/ybinsize;
     const DOUBLE zinv=1.0/zbinsize;
 
+    // First pass over the particles: compute cell indices
     for (int64_t i=0;i<NPART;i++)  {
         int ix=(int)((X[i]-xmin)*xinv) ;
         int iy=(int)((Y[i]-ymin)*yinv) ;
@@ -179,6 +139,7 @@ cellarray_DOUBLE * gridlink_DOUBLE(const int64_t NPART,
         if (ix>nmesh_x-1)  ix--;    /* this shouldn't happen, but . . . */
         if (iy>nmesh_y-1)  iy--;
         if (iz>nmesh_z-1)  iz--;
+        
         XRETURN(X[i] >= xmin && X[i] <= xmax, NULL,
                "x[%"PRId64"] = %"REAL_FORMAT" must be within [%"REAL_FORMAT",%"REAL_FORMAT"]\n",
                 i, X[i], xmin, xmax);
@@ -194,81 +155,101 @@ cellarray_DOUBLE * gridlink_DOUBLE(const int64_t NPART,
         XRETURN(iz >= 0 && iz < nmesh_z, NULL, "iz=%d must be within [0,%d)\n", iz, nmesh_z);
 
         const int64_t icell = CONVERT_3D_INDEX_TO_LINEAR(ix, iy, iz, nmesh_x, nmesh_y, nmesh_z);
-        if(options->copy_particles == 0) {
-            all_cell_indices[i] = icell;
+        assert(icell < totncells);
+        all_cell_indices[i] = icell;
+        if(!options->copy_particles){
             original_indices[i] = i;
+        }
+    }
+    
+    // Now determine the number of particles per cell so each cell knows its global starting index
+    // This information is used for both the copy and in-place versions
+    int Nthread = omp_get_max_threads();
+    int64_t *cell_occupation[Nthread];
+    //#pragma omp parallel for schedule(static)
+    for(int t = 0; t < Nthread; t++){
+        cell_occupation[t] = my_calloc(totncells, sizeof(int64_t));
+    }
+    //#pragma omp parallel for schedule(static)
+    for(int64_t i = 0; i < NPART; i++){
+        cell_occupation[omp_get_thread_num()][all_cell_indices[i]]++;
+    }
+    //#pragma omp parallel for schedule(static)
+    for(int64_t c = 0; c < totncells; c++){
+        for(int t = 1; t < Nthread; t++){
+            assert(cell_occupation[t][c] == 0);
+            cell_occupation[0][c] += cell_occupation[t][c];
+        }
+    }
+
+    // Cumulative sum of the cell histogram
+    cellstarts[0] = 0;
+    for(int64_t c = 1; c < totncells; c++){
+        cellstarts[c] = cell_occupation[0][c-1] + cellstarts[c-1];
+    }
+
+    // Initialize the lattice
+    //#pragma omp parallel for schedule(static)
+    for (int64_t icell=0;icell<totncells;icell++) {
+        lattice[icell].nelements = 0;
+        lattice[icell].owns_memory = 0;
+        lattice[icell].weights.num_weights = num_weights;
+        lattice[icell].xbounds[0] = MAX_POSITIVE_FLOAT;
+        lattice[icell].xbounds[1] = -MAX_POSITIVE_FLOAT;
+        lattice[icell].ybounds[0] = MAX_POSITIVE_FLOAT;
+        lattice[icell].ybounds[1] = -MAX_POSITIVE_FLOAT;
+        lattice[icell].zbounds[0] = MAX_POSITIVE_FLOAT;
+        lattice[icell].zbounds[1] = -MAX_POSITIVE_FLOAT;
+        lattice[icell].original_index = NULL;
+
+        // Now initialize each cell to point to its location in the global particle arrays
+        if(options->copy_particles) {
+            // The first cell will "own" the memory for the whole lattice
+            // This is safe because, by construction, the first cell has the original realX/Y/Z pointers
+            lattice[icell].owns_memory = icell == 0;
+            
+            // The lattice will point into the "real" arrays
+            lattice[icell].x = realX + cellstarts[icell];
+            lattice[icell].y = realY + cellstarts[icell];
+            lattice[icell].z = realZ + cellstarts[icell];
+
+            // Now do the same for the weights
+            for(int w = 0; w < num_weights; w++){
+                lattice[icell].weights.weights[w] = realW[w] + cellstarts[icell];
+            }
         } else {
+            // in-place also needs the original index
+            lattice[icell].original_index = original_indices + cellstarts[icell];
+                
+            // The lattice will point into the original arrays
+            lattice[icell].z = X + cellstarts[icell];
+            lattice[icell].y = Y + cellstarts[icell];
+            lattice[icell].z = Z + cellstarts[icell];
 
-            //check if we need to reallocate
-            if(lattice[icell].nelements == nallocated[icell]) {
-                expected_n = nallocated[icell]*MEMORY_INCREASE_FAC;
+            // Now do the same for the weights
+            for(int w = 0; w < num_weights; w++){
+                lattice[icell].weights.weights[w] = ((DOUBLE *) WEIGHTS->weights[w]) + cellstarts[icell];
+            }
+        }
+    }//end of loop over totncells
+    
+    free(cellstarts);
 
-                //In case expected_n is 1 or MEMORY_INCREASE_FAC is 1.
-                //This way, we only increase by a very few particles
-                // at a time. Smaller memory footprint
-                while(expected_n <= nallocated[icell])
-                    expected_n++;
-
-                DOUBLE *posx=NULL, *posy=NULL, *posz=NULL;
-                int64_t *orig_index=NULL;
-                int w_alloc_status;
-                do {
-
-                    posx = my_realloc(lattice[icell].x, sizeof(DOUBLE), expected_n, "lattice.x");
-                    posy = my_realloc(lattice[icell].y, sizeof(DOUBLE), expected_n, "lattice.y");
-                    posz = my_realloc(lattice[icell].z, sizeof(DOUBLE), expected_n, "lattice.z");
-                    orig_index = my_realloc(lattice[icell].original_index, sizeof(lattice[icell].original_index[0]), expected_n, "lattice.x");
-
-                    lattice[icell].x = (posx == NULL) ? lattice[icell].x:posx;
-                    lattice[icell].y = (posy == NULL) ? lattice[icell].y:posy;
-                    lattice[icell].z = (posz == NULL) ? lattice[icell].z:posz;
-                    lattice[icell].original_index = (orig_index == NULL) ? lattice[icell].original_index:orig_index;
-
-                    w_alloc_status = EXIT_SUCCESS;
-                    for(int w = 0; w < lattice[icell].weights.num_weights; w++){
-                        DOUBLE *newweights = (DOUBLE *) my_realloc(lattice[icell].weights.weights[w], sizeof(DOUBLE), expected_n, "lattice.weights");
-                        if(newweights == NULL){
-                            w_alloc_status = EXIT_FAILURE;
-                        } else {
-                            lattice[icell].weights.weights[w] = newweights;
-                        }
-                    }
-
-                    if(posx == NULL || posy == NULL || posz == NULL || orig_index == NULL ||w_alloc_status == EXIT_FAILURE) {
-                        expected_n--;
-                    }
-                } while(expected_n > nallocated[icell] && (posx == NULL ||
-                                                           posy == NULL ||
-                                                           posz == NULL ||
-                                                           orig_index == NULL ||
-                                                           w_alloc_status == EXIT_FAILURE));
-
-                if(expected_n == nallocated[icell]) {
-                    /*realloc failed. free memory and return */
-                    fprintf(stderr,"In %s> Reallocation failed,  randomly subsampling the input particle set (currently at %"PRId64" particles) might help\n",
-                            __FUNCTION__, NPART);
-                    free_cellarray_DOUBLE(lattice, totncells);
-                    free(nallocated);
-                    return NULL;
-                }
-                nallocated[icell] = expected_n;
-            }// successfully re-allocated memory to hold new particles (at least one more)
-
-            XRETURN(lattice[icell].nelements < nallocated[icell], NULL,
-                    ANSI_COLOR_RED"BUG: lattice[%"PRId64"].nelements = %"PRId64" must be less than allocated memory = %"PRId64 ANSI_COLOR_RESET"\n",
-                    icell, lattice[icell].nelements, nallocated[icell]);
-
+    // Second loop over particles: having computed the starts of each cell, fill the cells
+    for (int64_t i=0;i<NPART;i++) {
+        const int64_t icell = all_cell_indices[i];
+        if(options->copy_particles) {
             const int64_t ipos = lattice[icell].nelements;
             lattice[icell].x[ipos] = X[i];
             lattice[icell].y[ipos] = Y[i];
             lattice[icell].z[ipos] = Z[i];
-            lattice[icell].original_index[ipos] = i;
-            for(int w = 0; w < lattice[icell].weights.num_weights; w++){
+            for(int w = 0; w < num_weights; w++){
                 lattice[icell].weights.weights[w][ipos] = ((DOUBLE *) WEIGHTS->weights[w])[i];
             }
         }
 
-        //Store the particle bounds
+        // Store the particle bounds
+        // Needs to be done for both the copy and in-place versions
         lattice[icell].xbounds[0] = X[i] < lattice[icell].xbounds[0] ? X[i]:lattice[icell].xbounds[0];
         lattice[icell].ybounds[0] = Y[i] < lattice[icell].ybounds[0] ? Y[i]:lattice[icell].ybounds[0];
         lattice[icell].zbounds[0] = Z[i] < lattice[icell].zbounds[0] ? Z[i]:lattice[icell].zbounds[0];
@@ -279,13 +260,18 @@ cellarray_DOUBLE * gridlink_DOUBLE(const int64_t NPART,
 
         lattice[icell].nelements++;
     }
+    
+    for(int64_t c = 0; c < totncells; c++){
+        XRETURN(lattice[c].nelements == cell_occupation[0][c], NULL,
+                "Error in %s> Expected to assign all particles = %"PRId64" into cells but only seem "
+                "to have assigned %"PRId64".\n",
+                __FUNCTION__, cell_occupation[0][c], lattice[c].nelements);
+    }
+    
+    for(int t = 0; t < Nthread; t++)
+        free(cell_occupation[t]);
 
-    if(options->copy_particles) {
-        //All the particle positions have already been copied -> do not need to re-allocate any more
-        //You can free the extra memory reserved by the mallocs by looping over totncells
-        //and doing a realloc(lattice[cellindex].x,sizeof(DOUBLE),lattice[cellindex].nelements,"lattice.x")
-        free(nallocated);
-    } else {
+    if(!options->copy_particles) {
         // We have been told to work with the particle positions in-place i.e., not create a copy
         // of the particle positions within the lattice. Therefore, now we have to sort the
         // input particle positions to get them to be contiguous in their respective 3D cell
@@ -334,27 +320,9 @@ cellarray_DOUBLE * gridlink_DOUBLE(const int64_t NPART,
         //Now the particles are sorted contiguously according to their respective cellindex
         //We need to fix up the x/y/z pointers at the beginning of each cell to point to the right places
 #undef MULTIPLE_ARRAY_EXCHANGER
-
-        free(all_cell_indices);//Done with re-ordering the particles
-
-        int64_t nelements_so_far = 0;
-        for(int64_t icell=0;icell<totncells;icell++) {
-            cellarray_DOUBLE *first=&(lattice[icell]);
-            first->x = X + nelements_so_far;//take the base pointer address and add however many particles that have appeared summed across all previous cells
-            first->y = Y + nelements_so_far;
-            first->z = Z + nelements_so_far;
-            first->original_index = original_indices + nelements_so_far;
-            for(int w = 0; w < WEIGHTS->num_weights; w++) {
-                first->weights.weights[w] = ((DOUBLE *) WEIGHTS->weights[w]) + nelements_so_far;
-            }
-            nelements_so_far += first->nelements;
-        }
-        XRETURN(nelements_so_far == NPART, NULL,
-                "Error in %s> Expected to assign all particles = %"PRId64" into cells but only seem "
-                "to have assigned %"PRId64". Perhaps, there are some edge cases with floating point accuracy\n",
-                __FUNCTION__, NPART, nelements_so_far);
-
     }//end of options->copy_particles == 0
+    
+    free(all_cell_indices);  //Done with re-ordering the particles
 
     /* Do we need to sort the particles in Z ? */
     if(options->sort_on_z) {
@@ -369,7 +337,9 @@ cellarray_DOUBLE * gridlink_DOUBLE(const int64_t NPART,
                 SGLIB_ARRAY_ELEMENTS_EXCHANGER(DOUBLE, first->x, i, j); \
                 SGLIB_ARRAY_ELEMENTS_EXCHANGER(DOUBLE, first->y, i, j); \
                 SGLIB_ARRAY_ELEMENTS_EXCHANGER(DOUBLE, first->z, i, j); \
-                SGLIB_ARRAY_ELEMENTS_EXCHANGER(int64_t, first->original_index, i, j); \
+                if(!options->copy_particles) { \
+                    SGLIB_ARRAY_ELEMENTS_EXCHANGER(int64_t, first->original_index, i, j); \
+                } \
                 for(int w = 0; w < first->weights.num_weights; w++){    \
                     SGLIB_ARRAY_ELEMENTS_EXCHANGER(DOUBLE, ((DOUBLE *)first->weights.weights[w]), i, j); \
                 }                                                       \

--- a/utils/gridlink_impl.c.src
+++ b/utils/gridlink_impl.c.src
@@ -98,16 +98,16 @@ cellarray_DOUBLE * gridlink_DOUBLE(const int64_t NPART,
     int w_alloc_status = 0;
     int num_weights = (WEIGHTS == NULL) ? 0 : WEIGHTS->num_weights;
     
-    int64_t *cellstarts = (int64_t *) my_malloc(sizeof(int64_t), totncells);
+    int64_t *cellstarts = (int64_t *) my_malloc(sizeof(*cellstarts), totncells);
     int64_t *all_cell_indices = (int64_t *) my_malloc(sizeof(*all_cell_indices), NPART);
     int64_t *original_indices =  NULL;
     if(options->copy_particles) {
-        realX = (DOUBLE *) my_malloc(sizeof(DOUBLE), NPART);
-        realY = (DOUBLE *) my_malloc(sizeof(DOUBLE), NPART);
-        realZ = (DOUBLE *) my_malloc(sizeof(DOUBLE), NPART);
+        realX = (DOUBLE *) my_malloc(sizeof(*realX), NPART);
+        realY = (DOUBLE *) my_malloc(sizeof(*realY), NPART);
+        realZ = (DOUBLE *) my_malloc(sizeof(*realZ), NPART);
         
         for(int w = 0; w < num_weights; w++){
-            realW[w] = (DOUBLE *) my_malloc(sizeof(DOUBLE), NPART);
+            realW[w] = (DOUBLE *) my_malloc(sizeof(*(realW[w])), NPART);
             w_alloc_status |= realW[w] == NULL;
         }
     } else {
@@ -173,7 +173,7 @@ cellarray_DOUBLE * gridlink_DOUBLE(const int64_t NPART,
         #else
         int tid = 0;
         #endif
-        cell_occupation[tid] = my_calloc(totncells, sizeof(*cell_occupation[0]));
+        cell_occupation[tid] = my_calloc(sizeof(*(cell_occupation[0])), totncells);
         
         #if defined(_OPENMP)
         #pragma omp for schedule(static)

--- a/utils/gridlink_impl.c.src
+++ b/utils/gridlink_impl.c.src
@@ -253,6 +253,7 @@ cellarray_DOUBLE * gridlink_DOUBLE(const int64_t NPART,
         int nthreads = omp_get_num_threads();
         #else
         int tid = 0;
+        int nthreads = 1;
         #endif
         int64_t cstart = totncells*tid/nthreads;
         int64_t cend = totncells*(tid+1)/nthreads;

--- a/utils/gridlink_impl.c.src
+++ b/utils/gridlink_impl.c.src
@@ -32,21 +32,21 @@
 
 void free_cellarray_DOUBLE(cellarray_DOUBLE *lattice, const int64_t totncells)
 {
-    //In the case where we have not requested to copy particles.
-    //the memory address for the 'original_indices' from gridlink will be
-    //at the first cell. We need to free this memory to avoid a leak
+    // `totncells` is currently unused, but no need to break the C API.
+    (void) totncells;
+    
+    // If we have not copied the particles, the lattice does not own the memory
+    // and the only thing to free is the original index
     if(lattice[0].owns_memory == 0) {
         free(lattice[0].original_index);
     } else {
-        for(int64_t i=0;i<totncells;i++){
-            if(lattice[i].owns_memory) {
-                free(lattice[i].x);
-                free(lattice[i].y);
-                free(lattice[i].z);
-                for(int w = 0; w < lattice[i].weights.num_weights; w++){
-                    free(lattice[i].weights.weights[w]);
-                }
-            }
+        // If we have copied the particles, then the first cell (lattice[0]) owns
+        // the original pointers for the whole lattice, and we should free them
+        free(lattice[0].x);
+        free(lattice[0].y);
+        free(lattice[0].z);
+        for(int w = 0; w < lattice[0].weights.num_weights; w++){
+            free(lattice[0].weights.weights[w]);
         }
     }
 
@@ -98,7 +98,7 @@ cellarray_DOUBLE * gridlink_DOUBLE(const int64_t NPART,
     int w_alloc_status = 0;
     int num_weights = (WEIGHTS == NULL) ? 0 : WEIGHTS->num_weights;
     
-    int64_t *cellstarts = cellstarts = (int64_t *) my_malloc(sizeof(int64_t), totncells);
+    int64_t *cellstarts = (int64_t *) my_malloc(sizeof(int64_t), totncells);
     int64_t *all_cell_indices = (int64_t *) my_malloc(sizeof(*all_cell_indices), NPART);
     int64_t *original_indices =  NULL;
     if(options->copy_particles) {
@@ -157,34 +157,36 @@ cellarray_DOUBLE * gridlink_DOUBLE(const int64_t NPART,
     // Now determine the number of particles per cell so each cell knows its global starting index
     // This information is used for both the copy and in-place versions
 #if defined(_OPENMP)
-    int Nthread = omp_get_max_threads();
+    int max_nthreads = omp_get_max_threads();
 #else
-    int Nthread = 1;
+    int max_nthreads = 1;
 #endif
-    int64_t *cell_occupation[Nthread];
+    int64_t *cell_occupation[max_nthreads];
 
 #if defined(_OPENMP)
-    #pragma omp parallel for schedule(static)
+    #pragma omp parallel
 #endif
-    for(int t = 0; t < Nthread; t++){
-        cell_occupation[t] = my_calloc(totncells, sizeof(int64_t));
-    }
-#if defined(_OPENMP)
-    #pragma omp parallel for schedule(static)
-#endif
-    for(int64_t i = 0; i < NPART; i++){
+    {
         #if defined(_OPENMP)
         int tid = omp_get_thread_num();
         #else
         int tid = 0;
         #endif
-        cell_occupation[tid][all_cell_indices[i]]++;
+        cell_occupation[tid] = my_calloc(totncells, sizeof(int64_t));
+        
+        #if defined(_OPENMP)
+        #pragma omp for schedule(static)
+        #endif
+        for(int64_t i = 0; i < NPART; i++){
+            cell_occupation[tid][all_cell_indices[i]]++;
+        }
     }
+    
 #if defined(_OPENMP)
     #pragma omp parallel for schedule(static)
 #endif
     for(int64_t c = 0; c < totncells; c++){
-        for(int t = 1; t < Nthread; t++){
+        for(int t = 1; t < max_nthreads; t++){
             cell_occupation[0][c] += cell_occupation[t][c];
         }
     }
@@ -241,19 +243,21 @@ cellarray_DOUBLE * gridlink_DOUBLE(const int64_t NPART,
     
     free(cellstarts);
 
-    // Each thread is going to loop over all particles, but only process those in its cell domain
+    // Now we come to the final writes of the particles into their cells
 #if defined(_OPENMP)
     #pragma omp parallel
 #endif
     {
         #if defined(_OPENMP)
         int tid = omp_get_thread_num();
+        int nthreads = omp_get_num_threads();
         #else
         int tid = 0;
         #endif
-        int64_t cstart = totncells*tid/Nthread;
-        int64_t cend = totncells*(tid+1)/Nthread;
+        int64_t cstart = totncells*tid/nthreads;
+        int64_t cend = totncells*(tid+1)/nthreads;
         // Second loop over particles: having computed the starts of each cell, fill the cells
+        // Each thread is going to loop over all particles, but only process those in its cell domain
         for (int64_t i=0;i<NPART;i++) {
             const int64_t icell = all_cell_indices[i];
             if(icell < cstart || icell >= cend){
@@ -290,7 +294,7 @@ cellarray_DOUBLE * gridlink_DOUBLE(const int64_t NPART,
                 __FUNCTION__, cell_occupation[0][c], lattice[c].nelements);
     }
     
-    for(int t = 0; t < Nthread; t++)
+    for(int t = 0; t < max_nthreads; t++)
         free(cell_occupation[t]);
 
     if(!options->copy_particles) {
@@ -357,6 +361,7 @@ cellarray_DOUBLE * gridlink_DOUBLE(const int64_t NPART,
                 SGLIB_ARRAY_ELEMENTS_EXCHANGER(DOUBLE, first->x, i, j); \
                 SGLIB_ARRAY_ELEMENTS_EXCHANGER(DOUBLE, first->y, i, j); \
                 SGLIB_ARRAY_ELEMENTS_EXCHANGER(DOUBLE, first->z, i, j); \
+                /* original_index is not used if copying the particles */ \
                 if(!options->copy_particles) { \
                     SGLIB_ARRAY_ELEMENTS_EXCHANGER(int64_t, first->original_index, i, j); \
                 } \

--- a/utils/gridlink_impl.c.src
+++ b/utils/gridlink_impl.c.src
@@ -147,7 +147,7 @@ cellarray_DOUBLE * gridlink_DOUBLE(const int64_t NPART,
 
         const int64_t icell = CONVERT_3D_INDEX_TO_LINEAR(ix, iy, iz, nmesh_x, nmesh_y, nmesh_z);
         all_cell_indices[i] = icell;
-        if(!options->copy_particles){
+        if(options->copy_particles == 0){
             original_indices[i] = i;
         }
     }
@@ -172,7 +172,7 @@ cellarray_DOUBLE * gridlink_DOUBLE(const int64_t NPART,
         #else
         int tid = 0;
         #endif
-        cell_occupation[tid] = my_calloc(totncells, sizeof(int64_t));
+        cell_occupation[tid] = my_calloc(totncells, sizeof(*cell_occupation[0]));
         
         #if defined(_OPENMP)
         #pragma omp for schedule(static)

--- a/utils/utils.c
+++ b/utils/utils.c
@@ -850,23 +850,31 @@ int AlmostEqualRelativeAndAbs_double(double A, double B,
 
 /* #undef __USE_XOPEN2K */
 
-// A parallel cumulative sum
-// Output convention is: cumsum[0] = 0; cumsum[N-1] = sum(a[0:N-1]);
+/* A parallel cumulative sum
+   Output convention is: cumsum[0] = 0; cumsum[N-1] = sum(a[0:N-1]);
+   The algorithm is:
+   - Divide the array into `nthreads` chunks
+   - cumsum within each chunk
+   - compute the "offset" for each chunk by summing the cumsum at the tail of all previous chunks
+   - apply the offset
+*/
 void parallel_cumsum(const int64_t *a, const int64_t N, int64_t *cumsum){
     #ifdef _OPENMP
-    int Nthread = omp_get_max_threads();
+    int nthreads = omp_get_max_threads();
     #else
-    int Nthread = 1;
+    int nthreads = 1;
     #endif
     
     int64_t min_N_per_thread = 10000;  // heuristic to avoid overheads
-    if(N/min_N_per_thread < Nthread)
-        Nthread = N/min_N_per_thread;
-    if(Nthread < 1)
-        Nthread = 1;
+    if(N/min_N_per_thread < nthreads){
+        nthreads = N/min_N_per_thread;
+    }
+    if(nthreads < 1){
+        nthreads = 1;
+    }
     
     #ifdef _OPENMP
-    #pragma omp parallel num_threads(Nthread)
+    #pragma omp parallel num_threads(nthreads)
     #endif
     {
         #ifdef _OPENMP
@@ -875,8 +883,8 @@ void parallel_cumsum(const int64_t *a, const int64_t N, int64_t *cumsum){
         int tid = 0;
         #endif
         
-        int64_t cstart = N*tid/Nthread;
-        int64_t cend = N*(tid+1)/Nthread;
+        int64_t cstart = N*tid/nthreads;
+        int64_t cend = N*(tid+1)/nthreads;
         cumsum[cstart] = cstart > 0 ? a[cstart-1] : 0;
         for(int64_t c = cstart+1; c < cend; c++){
             cumsum[c] = a[c-1] + cumsum[c-1];
@@ -887,8 +895,9 @@ void parallel_cumsum(const int64_t *a, const int64_t N, int64_t *cumsum){
         #endif
         
         int64_t offset = 0;
-        for(int t = 0; t < tid; t++)
-            offset += cumsum[N*(t+1)/Nthread-1];
+        for(int t = 0; t < tid; t++){
+            offset += cumsum[N*(t+1)/nthreads-1];
+        }
         
         #ifdef _OPENMP
         #pragma omp barrier

--- a/utils/utils.c
+++ b/utils/utils.c
@@ -859,13 +859,21 @@ int AlmostEqualRelativeAndAbs_double(double A, double B,
    - apply the offset
 */
 void parallel_cumsum(const int64_t *a, const int64_t N, int64_t *cumsum){
+    if (N <= 0){
+        return;  // nothing to do
+    }
+    
     #ifdef _OPENMP
     int nthreads = omp_get_max_threads();
     #else
     int nthreads = 1;
     #endif
     
-    int64_t min_N_per_thread = 10000;  // heuristic to avoid overheads
+    // We will heuristically limit the number of threads
+    // if there isn't enough work for multithreading to be efficient.
+    // This is also important for the correctness of the algorithm below,
+    // since it enforces nthreads <= N
+    int64_t min_N_per_thread = 10000;
     if(N/min_N_per_thread < nthreads){
         nthreads = N/min_N_per_thread;
     }

--- a/utils/utils.h
+++ b/utils/utils.h
@@ -65,6 +65,8 @@ extern int test_all_files_present(const int nfiles, ...);
 /* Floating point comparison utilities */
 extern int AlmostEqualRelativeAndAbs_float(float A, float B, const float maxDiff, const float maxRelDiff);
 extern int AlmostEqualRelativeAndAbs_double(double A, double B, const double maxDiff, const double maxRelDiff);
+    
+extern void parallel_cumsum(const int64_t *a, const int64_t N, int64_t *cumsum);
 
 //end function declarations
 


### PR DESCRIPTION
Hey @manodeep, here's a stab at a parallel implementation of gridlink!  It was motivated by a recent example that popped up in my research where the actual pair counting was very fast (due to low sample density and low rmax), but gridlink took about the same amount of time as the counting, due to the large Nmesh, and thus large number of mallocs and single-threaded particle writes.  This version does one malloc for the whole grid (in detail, one malloc for each X/Y/Z/W column of particle data), calculates cell assignments in parallel, then uses that information to do parallel writes of the particle data into the appropriate cells.

Because this parallelization requires two reads of the particle data instead of one, I expected that the new version running with one thread might be slower than the old single-threaded code, especially at high particles-per-cell where the malloc overhead is lower.  However, that does not appear to be the case in benchmarks.  The reads are probably cheap compared to the writes, and it's possible that there are vectorization opportunities, e.g. in the computation of the cell index, that are present in this version that were not present in the old version.

Old:
```
   6.0 ms (Ngrid   10, N     100000, ppc    100,  1 threads)
  54.4 ms (Ngrid   10, N    1000000, ppc   1000,  1 threads)
 556.5 ms (Ngrid   10, N   10000000, ppc  10000,  1 threads)
5166.1 ms (Ngrid   10, N  100000000, ppc 100000,  1 threads)
  68.9 ms (Ngrid   20, N    1000000, ppc    125,  1 threads)
 137.3 ms (Ngrid   40, N    1000000, ppc     15,  1 threads)
 313.0 ms (Ngrid  100, N    1000000, ppc      1,  1 threads)
```
New:
```
   4.4 ms (Ngrid   10, N     100000, ppc    100,  1 threads)
  34.5 ms (Ngrid   10, N    1000000, ppc   1000,  1 threads)
 338.9 ms (Ngrid   10, N   10000000, ppc  10000,  1 threads)
3472.7 ms (Ngrid   10, N  100000000, ppc 100000,  1 threads)
  46.6 ms (Ngrid   20, N    1000000, ppc    125,  1 threads)
  75.2 ms (Ngrid   40, N    1000000, ppc     15,  1 threads)
 150.1 ms (Ngrid  100, N    1000000, ppc      1,  1 threads)
```

New, parallel:
```
   2.3 ms (Ngrid   10, N     100000, ppc    100, 12 threads)
   8.5 ms (Ngrid   10, N    1000000, ppc   1000, 12 threads)
  70.5 ms (Ngrid   10, N   10000000, ppc  10000, 12 threads)
 721.8 ms (Ngrid   10, N  100000000, ppc 100000, 12 threads)
   9.9 ms (Ngrid   20, N    1000000, ppc    125, 12 threads)
  11.0 ms (Ngrid   40, N    1000000, ppc     15, 12 threads)
  32.8 ms (Ngrid  100, N    1000000, ppc      1, 12 threads)
```

These are direct benchmarks of `gridlink_double()` (i.e. calling directly with C code; mean of 10 runs) on a 12 core, 2 socket Intel machine.  No `sort_on_z`, since that part is unchanged between the old and new versions.  The thread scaling is far from perfect, but it's a nice little speedup.  I expect this will be most helpful in latency-sensitive applications like HOD evaluations.  The benchmark data is uniform random, but I've spot-checked with clustered data, which looks similar (and may be an even bigger win, because no more reallocs).

The tests all pass, and I've checked with and without OpenMP and `copy_particles`.  Could you take a look and let me know what you think?