### PR TITLE
Add runtime environment check for NERSC Cray hugepages

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ jobs:
       fail-fast: false
       matrix:
         os: ["ubuntu-16.04", "ubuntu-18.04", "ubuntu-20.04", "macos-latest"]
-        compiler: [gcc-7, gcc-8, gcc-9, clang]
+        compiler: [gcc-7, gcc-9, gcc-10, clang]
         python-version: ["2.7", "3.5", "3.6", "3.7", "3.8"]
         numpy-version: ["1.14", "1.16", "1.18"]
         exclude:
@@ -19,29 +19,29 @@ jobs:
           - os: "macos-latest"
             compiler: gcc-7
           - os: "macos-latest"
-            compiler: gcc-8
-          - os: "macos-latest"
             compiler: gcc-9
+          - os: "macos-latest"
+            compiler: gcc-10
 
           # Don't use 'clang' on linux
+          - os: "ubuntu-16.04"
+            compiler: clang
           - os: "ubuntu-18.04"
             compiler: clang
           - os: "ubuntu-20.04"
             compiler: clang
-          - os: "ubuntu-16.04"
-            compiler: clang
 
-          # only gcc-9 on 20.04
+          # only gcc-10 on 20.04
+          - os: "ubuntu-20.04"
+            compiler: gcc-9
           - os: "ubuntu-20.04"
             compiler: gcc-7
-          - os: "ubuntu-20.04"
-            compiler: gcc-8
 
-          # only gcc-7 on 16.04
+          # only gcc-9 on 16.04
           - os: "ubuntu-16.04"
-            compiler: gcc-8
+            compiler: gcc-7
           - os: "ubuntu-16.04"
-            compiler: gcc-9
+            compiler: gcc-10
 
           # python3.8 only on 20.04
           - os: "ubuntu-16.04"

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -17,6 +17,7 @@ Enhancements
 ------------
 - In the theoretical VPF calculation (``theory.vpf``), the total volume of the random spheres can now exceed the volume of the sample  [#238]
 - Gridlink (the binning of particles into cells) now uses a parallel algorithm for the theory module [#239]
+- Add detection of known-bad Cray hugepages library at NERSC [#246]
 
 Bug fixes
 ---------

--- a/Corrfunc/__init__.py
+++ b/Corrfunc/__init__.py
@@ -24,6 +24,8 @@ if not __CORRFUNC_SETUP__:
     from . import utils
     from . import theory
     from . import mocks
+    
+    utils.check_runtime_env()
 
 
 def read_text_file(filename, encoding="utf-8"):

--- a/Corrfunc/__init__.py
+++ b/Corrfunc/__init__.py
@@ -24,7 +24,7 @@ if not __CORRFUNC_SETUP__:
     from . import utils
     from . import theory
     from . import mocks
-    
+
     utils.check_runtime_env()
 
 

--- a/Corrfunc/utils.py
+++ b/Corrfunc/utils.py
@@ -1067,7 +1067,7 @@ def check_runtime_env():
     # Check if Cray hugepages is enabled at NERSC, which will crash
     # C Python extensions due to a hugepages bug
     if 'NERSC_HOST' in os.environ and os.getenv('HUGETLB_DEFAULT_PAGE_SIZE'):
-        warnings.warn('Warning: Cray hugepages has a bug that may crash 
+        warnings.warn('Warning: Cray hugepages has a bug that may crash '
                       'Corrfunc. You might be able to fix such a crash with '
                       '`module unload craype-hugepages2M` (see '
                       'https://github.com/manodeep/Corrfunc/issues/245 '

--- a/Corrfunc/utils.py
+++ b/Corrfunc/utils.py
@@ -1056,19 +1056,22 @@ def sys_pipes():
             yield
     except:
         yield
-        
+
+
 def check_runtime_env():
     '''
     Detect any computing environment conditions that may cause Corrfunc
     to fail, and inform the user if there is any action they can take.
     '''
-    
+
     # Check if Cray hugepages is enabled at NERSC, which will crash
     # C Python extensions due to a hugepages bug
     if 'NERSC_HOST' in os.environ and os.getenv('HUGETLB_DEFAULT_PAGE_SIZE'):
-        warnings.warn('Warning: Cray hugepages has a bug that may crash Corrfunc. '
-                      'You might be able to fix such a crash with `module unload craype-hugepages2M` '
-                      '(see https://github.com/manodeep/Corrfunc/issues/245 for details)')
+        warnings.warn('Warning: Cray hugepages has a bug that may crash 
+                      'Corrfunc. You might be able to fix such a crash with '
+                      '`module unload craype-hugepages2M` (see '
+                      'https://github.com/manodeep/Corrfunc/issues/245 '
+                      'for details)')
 
 if __name__ == '__main__':
     import doctest

--- a/Corrfunc/utils.py
+++ b/Corrfunc/utils.py
@@ -6,7 +6,10 @@ A set of utility routines
 from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 import sys
+import os
+import warnings
 from os.path import exists as file_exists
+
 import wurlitzer
 from contextlib import contextmanager
 
@@ -1053,6 +1056,19 @@ def sys_pipes():
             yield
     except:
         yield
+        
+def check_runtime_env():
+    '''
+    Detect any computing environment conditions that may cause Corrfunc
+    to fail, and inform the user if there is any action they can take.
+    '''
+    
+    # Check if Cray hugepages is enabled at NERSC, which will crash
+    # C Python extensions due to a hugepages bug
+    if 'NERSC_HOST' in os.environ and os.getenv('HUGETLB_DEFAULT_PAGE_SIZE'):
+        warnings.warn('Warning: Cray hugepages has a bug that may crash Corrfunc. '
+                      'You might be able to fix such a crash with `module unload craype-hugepages2M` '
+                      '(see https://github.com/manodeep/Corrfunc/issues/245 for details)')
 
 if __name__ == '__main__':
     import doctest


### PR DESCRIPTION
As discussed in #244 and #245.  The runtime check is called from `__init__.py`, which avoids having to put the check inside each Python module.

I tested this at NERSC and it works as expected, with and without the hugepages module loaded.