### PR TITLE
Fix parsing error when periodic=False and boxsize not given in the theory module

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -35,6 +35,7 @@ Enhancements
 Bug fixes
 ---------
 - Fix Python reference leak to results struct [#229]
+- Fix parsing error when ``periodic=False`` and ``boxsize`` not given in the theory module [#257]
 
 
 2.3.4 (2019-07-21)

--- a/Corrfunc/theory/DD.py
+++ b/Corrfunc/theory/DD.py
@@ -228,7 +228,7 @@ def DD(autocorr, nthreads, binfile, X1, Y1, Z1, weights1=None, periodic=True,
 
     # Passing None parameters breaks the parsing code, so avoid this
     kwargs = {}
-    for k in ['weights1', 'weights2', 'weight_type', 'X2', 'Y2', 'Z2']:
+    for k in ['weights1', 'weights2', 'weight_type', 'X2', 'Y2', 'Z2', 'boxsize']:
         v = locals()[k]
         if v is not None:
             kwargs[k] = v
@@ -241,7 +241,6 @@ def DD(autocorr, nthreads, binfile, X1, Y1, Z1, weights1=None, periodic=True,
                               X1, Y1, Z1,
                               periodic=periodic,
                               verbose=verbose,
-                              boxsize=boxsize,
                               output_ravg=output_ravg,
                               xbin_refine_factor=xbin_refine_factor,
                               ybin_refine_factor=ybin_refine_factor,

--- a/Corrfunc/theory/DD.py
+++ b/Corrfunc/theory/DD.py
@@ -228,7 +228,8 @@ def DD(autocorr, nthreads, binfile, X1, Y1, Z1, weights1=None, periodic=True,
 
     # Passing None parameters breaks the parsing code, so avoid this
     kwargs = {}
-    for k in ['weights1', 'weights2', 'weight_type', 'X2', 'Y2', 'Z2', 'boxsize']:
+    for k in ['weights1', 'weights2', 'weight_type',
+              'X2', 'Y2', 'Z2', 'boxsize']:
         v = locals()[k]
         if v is not None:
             kwargs[k] = v

--- a/Corrfunc/theory/DDrppi.py
+++ b/Corrfunc/theory/DDrppi.py
@@ -279,7 +279,8 @@ def DDrppi(autocorr, nthreads, pimax, binfile, X1, Y1, Z1, weights1=None,
 
     # Passing None parameters breaks the parsing code, so avoid this
     kwargs = {}
-    for k in ['weights1', 'weights2', 'weight_type', 'X2', 'Y2', 'Z2', 'boxsize']:
+    for k in ['weights1', 'weights2', 'weight_type',
+              'X2', 'Y2', 'Z2', 'boxsize']:
         v = locals()[k]
         if v is not None:
             kwargs[k] = v

--- a/Corrfunc/theory/DDrppi.py
+++ b/Corrfunc/theory/DDrppi.py
@@ -279,7 +279,7 @@ def DDrppi(autocorr, nthreads, pimax, binfile, X1, Y1, Z1, weights1=None,
 
     # Passing None parameters breaks the parsing code, so avoid this
     kwargs = {}
-    for k in ['weights1', 'weights2', 'weight_type', 'X2', 'Y2', 'Z2']:
+    for k in ['weights1', 'weights2', 'weight_type', 'X2', 'Y2', 'Z2', 'boxsize']:
         v = locals()[k]
         if v is not None:
             kwargs[k] = v
@@ -293,7 +293,6 @@ def DDrppi(autocorr, nthreads, pimax, binfile, X1, Y1, Z1, weights1=None,
                                  X1, Y1, Z1,
                                  periodic=periodic,
                                  verbose=verbose,
-                                 boxsize=boxsize,
                                  output_rpavg=output_rpavg,
                                  xbin_refine_factor=xbin_refine_factor,
                                  ybin_refine_factor=ybin_refine_factor,

--- a/Corrfunc/theory/DDsmu.py
+++ b/Corrfunc/theory/DDsmu.py
@@ -295,7 +295,8 @@ def DDsmu(autocorr, nthreads, binfile, mu_max, nmu_bins,
 
     # Passing None parameters breaks the parsing code, so avoid this
     kwargs = {}
-    for k in ['weights1', 'weights2', 'weight_type', 'X2', 'Y2', 'Z2', 'boxsize']:
+    for k in ['weights1', 'weights2', 'weight_type',
+              'X2', 'Y2', 'Z2', 'boxsize']:
         v = locals()[k]
         if v is not None:
             kwargs[k] = v

--- a/Corrfunc/theory/DDsmu.py
+++ b/Corrfunc/theory/DDsmu.py
@@ -295,7 +295,7 @@ def DDsmu(autocorr, nthreads, binfile, mu_max, nmu_bins,
 
     # Passing None parameters breaks the parsing code, so avoid this
     kwargs = {}
-    for k in ['weights1', 'weights2', 'weight_type', 'X2', 'Y2', 'Z2']:
+    for k in ['weights1', 'weights2', 'weight_type', 'X2', 'Y2', 'Z2', 'boxsize']:
         v = locals()[k]
         if v is not None:
             kwargs[k] = v
@@ -309,7 +309,6 @@ def DDsmu(autocorr, nthreads, binfile, mu_max, nmu_bins,
                                   X1, Y1, Z1,
                                   periodic=periodic,
                                   verbose=verbose,
-                                  boxsize=boxsize,
                                   output_savg=output_savg,
                                   fast_divide_and_NR_steps=fast_divide_and_NR_steps,
                                   xbin_refine_factor=xbin_refine_factor,

--- a/Corrfunc/theory/vpf.py
+++ b/Corrfunc/theory/vpf.py
@@ -200,8 +200,12 @@ def vpf(rmax, nbins, nspheres, numpN, seed,
         msg = "Number of counts-in-cells wanted must be at least 1"
         raise ValueError(msg)
 
-    if periodic and boxsize is None:
-        raise ValueError("Must specify a boxsize if periodic=True")
+    kwargs = {}
+    if boxsize is None:
+        if periodic:
+            raise ValueError("Must specify a boxsize if periodic=True")
+    else:
+        kwargs['boxsize'] = boxsize
 
     # Ensure all input arrays are native endian
     X, Y, Z = [convert_to_native_endian(arr, warn=True)
@@ -216,14 +220,14 @@ def vpf(rmax, nbins, nspheres, numpN, seed,
                               X, Y, Z,
                               verbose=verbose,
                               periodic=periodic,
-                              boxsize=boxsize,
                               xbin_refine_factor=xbin_refine_factor,
                               ybin_refine_factor=ybin_refine_factor,
                               zbin_refine_factor=zbin_refine_factor,
                               max_cells_per_dim=max_cells_per_dim,
                               copy_particles=copy_particles,
                               c_api_timer=c_api_timer,
-                              isa=integer_isa)
+                              isa=integer_isa,
+                              **kwargs)
     if extn_results is None:
         msg = "RuntimeError occurred"
         raise RuntimeError(msg)

--- a/Corrfunc/theory/vpf.py
+++ b/Corrfunc/theory/vpf.py
@@ -202,7 +202,7 @@ def vpf(rmax, nbins, nspheres, numpN, seed,
 
     if periodic and boxsize is None:
         raise ValueError("Must specify a boxsize if periodic=True")
-        
+
     kwargs = {}
     if boxsize is not None:
         kwargs['boxsize'] = boxsize

--- a/Corrfunc/theory/vpf.py
+++ b/Corrfunc/theory/vpf.py
@@ -200,11 +200,11 @@ def vpf(rmax, nbins, nspheres, numpN, seed,
         msg = "Number of counts-in-cells wanted must be at least 1"
         raise ValueError(msg)
 
+    if periodic and boxsize is None:
+        raise ValueError("Must specify a boxsize if periodic=True")
+        
     kwargs = {}
-    if boxsize is None:
-        if periodic:
-            raise ValueError("Must specify a boxsize if periodic=True")
-    else:
+    if boxsize is not None:
         kwargs['boxsize'] = boxsize
 
     # Ensure all input arrays are native endian


### PR DESCRIPTION
From #256, don't pass a boxsize of `None` to the C extensions.