### PR TITLE
Add additional check to tell if it's safe to redirect stdout/err

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -20,6 +20,10 @@ Changes
 - Migrate doctests to Python 3.8 [#261]
 - Migrate Python tests to pytest [#265]
 
+Fixes
+-----
+- Add additional check to tell if it's safe to redirect stdout/err [#270]
+
 
 2.4.0 (2021-09-30)
 ==================

--- a/Corrfunc/utils.py
+++ b/Corrfunc/utils.py
@@ -1034,8 +1034,8 @@ def sys_pipes():
     uses os.dup2 to redirect fds 1 & 2 to the new location and restore them on return,
     but will cause the output to hang if they were not already redirected.  It seems
     we can compare Python's ``sys.stdout`` to the saved ``sys.__stdout__`` to tell
-    if redirection occurred.  We can also check if the output is a TTY, but that's
-    probably a subset of the preceeding check.
+    if redirection occurred.  We will also check if the output is a TTY as a safety
+    net, even though it is probably a subset of the preceeding check.
 
     Basic usage is:
 

--- a/Corrfunc/utils.py
+++ b/Corrfunc/utils.py
@@ -1029,12 +1029,13 @@ def process_weights(weights1, weights2, X1, X2, weight_type, autocorr):
 @contextmanager
 def sys_pipes():
     '''
-    We can use the Wurlitzer package to redirect stdout and stderr
-    from the command line into a Jupyter notebook.  But if we're not
-    in a notebook, this isn't safe because we can't redirect stdout
-    to itself.  This function is a thin wrapper that checks if the
-    stdout/err streams are TTYs and enables output redirection
-    based on that.
+    In a Jupyter notebook, Python's ``sys.stdout`` and ``sys.stderr`` are redirected
+    so output ends up in cells.  But C extensions don't know about that!  Wurlitzer
+    uses os.dup2 to redirect fds 1 & 2 to the new location and restore them on return,
+    but will cause the output to hang if they were not already redirected.  It seems
+    we can compare Python's ``sys.stdout`` to the saved ``sys.__stdout__`` to tell
+    if redirection occurred.  We can also check if the output is a TTY, but that's
+    probably a subset of the preceeding check.
 
     Basic usage is:
 
@@ -1042,11 +1043,19 @@ def sys_pipes():
     ...    call_some_c_function()
 
     See the Wurlitzer package for usage of `wurlitzer.pipes()`;
-    see also https://github.com/manodeep/Corrfunc/issues/157.
+    see also https://github.com/manodeep/Corrfunc/issues/157,
+    https://github.com/manodeep/Corrfunc/issues/269.
     '''
-
-    kwargs = {'stdout':None if sys.stdout.isatty() else sys.stdout,
-              'stderr':None if sys.stderr.isatty() else sys.stderr }
+    
+    kwargs = {}
+    if sys.stdout.isatty() or (sys.stdout is sys.__stdout__):
+        kwargs['stdout'] = None
+    else:
+        kwargs['stdout'] = sys.stdout
+    if sys.stderr.isatty() or (sys.stderr is sys.__stderr__):
+        kwargs['stderr'] = None
+    else:
+        kwargs['stderr'] = sys.stderr
 
     # Redirection might break for any number of reasons, like
     # stdout/err already being closed/redirected.  We probably


### PR DESCRIPTION
From #269, invoking a Corrfunc script as `python -u script.py &> out.txt` causes the script to hang.  Something about the combination of redirection and unbuffered output was causing trouble.  This change adds an additional check, `sys.stdout is sys.__stdout__`, to see if Python's `sys.stdout` has been redirected elsewhere, like a Jupyter cell, in which case we want to follow that redirect. Otherwise, we don't touch anything.

I don't exactly understand why unbuffered output causes a problem when buffered output did not, but I'm pretty confident that this new check more accurately reflects the scenarios in which we actually want redirection.  This new check probably supersedes the `sys.stdout.isatty()` check, but to be conservative, we'll keep both.

Minimal reproducer, note it is completely unrelated to Corrfunc:
```python
import sys

import wurlitzer
    
with wurlitzer.pipes(stderr=sys.stderr):
    print('hello, there!', file=sys.stderr)
```

```console
$ python repro.py 2> eout.txt  # fine
$ python -u repro.py 2> eout.txt  # hangs
```


This probably reflects my ignorance around pipes and fd's more than anything else!