### PR TITLE
Removed cz fixing for comoving distances

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -23,7 +23,7 @@ Changes
 Fixes
 -----
 - Add additional check to tell if it's safe to redirect stdout/err [#270]
-- Perform z vs cz check and fixing only if comoving distance flag is not set [#275]
+- Check and fix ``z`` vs ``cz`` in ``DDrppi_mocks`` and ``DDsmu_mocks`` only if comoving distance flag is not set [#275]
 
 
 2.4.0 (2021-09-30)

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -23,6 +23,7 @@ Changes
 Fixes
 -----
 - Add additional check to tell if it's safe to redirect stdout/err [#270]
+- Perform z vs cz check and fixing only if comoving distance flag is not set [#275]
 
 
 2.4.0 (2021-09-30)

--- a/mocks/DDrppi_mocks/countpairs_rp_pi_mocks_impl.c.src
+++ b/mocks/DDrppi_mocks/countpairs_rp_pi_mocks_impl.c.src
@@ -40,7 +40,7 @@ void interrupt_handler_countpairs_rp_pi_mocks_DOUBLE(int signo)
 }
 
 
-int check_ra_dec_cz_DOUBLE(const int64_t N, DOUBLE *phi, DOUBLE *theta, DOUBLE *cz)
+int check_ra_dec_cz_DOUBLE(const int64_t N, DOUBLE *phi, DOUBLE *theta, DOUBLE *cz, const uint8_t is_comoving_dist)
 {
 
     if(N==0) {
@@ -71,7 +71,7 @@ int check_ra_dec_cz_DOUBLE(const int64_t N, DOUBLE *phi, DOUBLE *theta, DOUBLE *
             return EXIT_FAILURE;
         }
     }
-    if(max_cz < max_cz_threshold) fix_cz = 1;
+    if((max_cz < max_cz_threshold) && (is_comoving_dist == 0)) fix_cz = 1; // only fix "cz" if it's not comoving distance but indeed cz
 
     //Only run the loop if something needs to be fixed
     if(fix_cz==1 || fix_ra == 1 || fix_dec == 1) {
@@ -246,12 +246,12 @@ int countpairs_mocks_DOUBLE(const int64_t ND1, DOUBLE *ra1, DOUBLE *dec1, DOUBLE
     }
 
     //Check inputs
-    int status1 = check_ra_dec_cz_DOUBLE(ND1, ra1, dec1, czD1);
+    int status1 = check_ra_dec_cz_DOUBLE(ND1, ra1, dec1, czD1, options->is_comoving_dist);
     if(status1 != EXIT_SUCCESS) {
         return status1;
     }
     if(autocorr==0) {
-        int status2 = check_ra_dec_cz_DOUBLE(ND2, ra2, dec2, czD2);
+        int status2 = check_ra_dec_cz_DOUBLE(ND2, ra2, dec2, czD2, options->is_comoving_dist);
         if(status2 != EXIT_SUCCESS) {
             return status2;
         }

--- a/mocks/DDrppi_mocks/countpairs_rp_pi_mocks_impl.h.src
+++ b/mocks/DDrppi_mocks/countpairs_rp_pi_mocks_impl.h.src
@@ -44,7 +44,7 @@ extern "C" {
                                        results_countpairs_mocks *results,
                                        struct config_options *options, struct extra_options *extra);
     
-    extern int check_ra_dec_cz_DOUBLE(const int64_t N, DOUBLE *phi, DOUBLE *theta, DOUBLE *cz);
+    extern int check_ra_dec_cz_DOUBLE(const int64_t N, DOUBLE *phi, DOUBLE *theta, DOUBLE *cz, const uint8_t is_comoving_dist);
     
 #ifdef __cplusplus
 }

--- a/mocks/DDsmu_mocks/countpairs_s_mu_mocks_impl.c.src
+++ b/mocks/DDsmu_mocks/countpairs_s_mu_mocks_impl.c.src
@@ -41,7 +41,7 @@ void interrupt_handler_countpairs_s_mu_mocks_DOUBLE(int signo)
 }
 
 
-int check_ra_dec_cz_s_mu_DOUBLE(const int64_t N, DOUBLE *phi, DOUBLE *theta, DOUBLE *cz)
+int check_ra_dec_cz_s_mu_DOUBLE(const int64_t N, DOUBLE *phi, DOUBLE *theta, DOUBLE *cz, int is_comoving_dist)
 {
 
     if(N==0) {
@@ -72,7 +72,7 @@ int check_ra_dec_cz_s_mu_DOUBLE(const int64_t N, DOUBLE *phi, DOUBLE *theta, DOU
             return EXIT_FAILURE;
         }
     }
-    if(max_cz < max_cz_threshold) fix_cz = 1;
+    if((max_cz < max_cz_threshold) && (is_comoving_dist == 0)) fix_cz = 1; // only fix "cz" if it's not comoving distance but indeed cz
 
     //Only run the loop if something needs to be fixed
     if(fix_cz==1 || fix_ra == 1 || fix_dec == 1) {
@@ -248,12 +248,12 @@ int countpairs_mocks_s_mu_DOUBLE(const int64_t ND1, DOUBLE *ra1, DOUBLE *dec1, D
     }
 
     //Check inputs
-    int status1 = check_ra_dec_cz_s_mu_DOUBLE(ND1, ra1, dec1, czD1);
+    int status1 = check_ra_dec_cz_s_mu_DOUBLE(ND1, ra1, dec1, czD1, options->is_comoving_dist);
     if(status1 != EXIT_SUCCESS) {
         return status1;
     }
     if(autocorr==0) {
-        int status2 = check_ra_dec_cz_s_mu_DOUBLE(ND2, ra2, dec2, czD2);
+        int status2 = check_ra_dec_cz_s_mu_DOUBLE(ND2, ra2, dec2, czD2, options->is_comoving_dist);
         if(status2 != EXIT_SUCCESS) {
             return status2;
         }

--- a/mocks/DDsmu_mocks/countpairs_s_mu_mocks_impl.c.src
+++ b/mocks/DDsmu_mocks/countpairs_s_mu_mocks_impl.c.src
@@ -41,7 +41,7 @@ void interrupt_handler_countpairs_s_mu_mocks_DOUBLE(int signo)
 }
 
 
-int check_ra_dec_cz_s_mu_DOUBLE(const int64_t N, DOUBLE *phi, DOUBLE *theta, DOUBLE *cz, int is_comoving_dist)
+int check_ra_dec_cz_s_mu_DOUBLE(const int64_t N, DOUBLE *phi, DOUBLE *theta, DOUBLE *cz, const uint8_t is_comoving_dist)
 {
 
     if(N==0) {

--- a/mocks/DDsmu_mocks/countpairs_s_mu_mocks_impl.h.src
+++ b/mocks/DDsmu_mocks/countpairs_s_mu_mocks_impl.h.src
@@ -46,7 +46,7 @@ extern "C" {
                                             results_countpairs_mocks_s_mu *results,
                                             struct config_options *options, struct extra_options *extra);
 
-    extern int check_ra_dec_cz_s_mu_DOUBLE(const int64_t N, DOUBLE *phi, DOUBLE *theta, DOUBLE *cz);
+    extern int check_ra_dec_cz_s_mu_DOUBLE(const int64_t N, DOUBLE *phi, DOUBLE *theta, DOUBLE *cz, int is_comoving_dist);
 
 #ifdef __cplusplus
 }

--- a/mocks/DDsmu_mocks/countpairs_s_mu_mocks_impl.h.src
+++ b/mocks/DDsmu_mocks/countpairs_s_mu_mocks_impl.h.src
@@ -46,7 +46,7 @@ extern "C" {
                                             results_countpairs_mocks_s_mu *results,
                                             struct config_options *options, struct extra_options *extra);
 
-    extern int check_ra_dec_cz_s_mu_DOUBLE(const int64_t N, DOUBLE *phi, DOUBLE *theta, DOUBLE *cz, int is_comoving_dist);
+    extern int check_ra_dec_cz_s_mu_DOUBLE(const int64_t N, DOUBLE *phi, DOUBLE *theta, DOUBLE *cz, const uint8_t is_comoving_dist);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
When `is_comoving_dist` is set, cz is actually comoving distance, therefore fixing the inputs by speed of light doesn't make sense, as simplest resolution of this problem I don't set `fix_cz` then. Fixes #274.