### PR TITLE
WIP: enable larger Rmax (up to half the box size)

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -17,6 +17,7 @@ New features
 Enhancements
 ------------
 - Allow user to specify periodicity and box size per dimension [#276]
+- Allow larger Rmax (up to half the boxsize) [#277]
 
 Changes
 -------

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -29,6 +29,7 @@ Fixes
 -----
 - Add additional check to tell if it's safe to redirect stdout/err [#270]
 - Check and fix ``z`` vs ``cz`` in ``DDrppi_mocks`` and ``DDsmu_mocks`` only if comoving distance flag is not set [#275]
+- Update GNU assembler bug detection [#278]
 
 
 2.4.0 (2021-09-30)

--- a/Corrfunc/tests/test_theory.py
+++ b/Corrfunc/tests/test_theory.py
@@ -155,6 +155,34 @@ def test_large_Rmax(N, isa='fastest', nthreads=maxthreads()):
         assert np.all(results['npairs'] == [0, 2])
 
 
+def test_duplicate_cellpairs(isa='fastest', nthreads=maxthreads()):
+    '''A test to implement Manodeep's example from
+    https://github.com/manodeep/Corrfunc/pull/277#issuecomment-1190921894
+    '''
+    from Corrfunc.theory import DD
+    boxsize = 1.
+    autocorr = 1
+    r_bins = [0.01, 0.1]
+    pos = np.array([[0.02, 0.98],
+                    [0., 0.],
+                    [0., 0.0],
+                    ])
+
+    results = DD(autocorr, nthreads, r_bins, pos[0], pos[1], pos[2],
+                 boxsize=boxsize, periodic=True,
+                 verbose=True)
+
+    assert np.all(results['npairs'] == [2])
+
+    autocorr = 0
+    results = DD(autocorr, nthreads, r_bins, pos[0], pos[1], pos[2],
+                 X2=pos[0], Y2=pos[1], Z2=pos[2],
+                 boxsize=boxsize, periodic=True,
+                 verbose=True)
+
+    assert np.all(results['npairs'] == [2])
+
+
 
 @pytest.mark.parametrize('isa,nthreads', generate_isa_and_nthreads_combos())
 def test_DDrppi(gals_Mr19, isa, nthreads):

--- a/Corrfunc/tests/test_theory.py
+++ b/Corrfunc/tests/test_theory.py
@@ -201,8 +201,14 @@ def test_rmax_against_brute(autocorr, binref, min_sep_opt, maxcells,
     pos[:, npts//2:] += boxsize/2.  # second cloud is in center of box
     pos %= boxsize
 
-    pdiff = np.abs(pos[:, None] - pos[:, :, None])
+    # Compute the pairwise distance between particles with broadcasting.
+    # Broadcasting (3,1,npts) against (3,npts,1) yields (3,npts,npts),
+    # which is the array of all npts^2 (x,y,z) differences.
+    pdiff = np.abs(pos[:, np.newaxis] - pos[:, :, np.newaxis])
     pdiff[pdiff >= boxsize/2] -= boxsize
+
+    # Compute dist^2 = x^2 + y^2 + z^2, flattening because we don't
+    # care which dist came from which particle pair
     pdiff = (pdiff**2).sum(axis=0).reshape(-1)
     brutecounts, _ = np.histogram(pdiff, bins=bins**2)
 

--- a/Corrfunc/tests/test_theory.py
+++ b/Corrfunc/tests/test_theory.py
@@ -131,56 +131,51 @@ def test_narrow_extent(N, isa='fastest', nthreads=maxthreads()):
         assert np.all(results['npairs'] == [0, 0])
 
 
-@pytest.mark.parametrize('N', [2])
-def test_large_Rmax(N, isa='fastest', nthreads=maxthreads()):
-    '''Test that an Rmax comparable to the boxsize gives the right answer
-    '''
-    from Corrfunc.theory import DD
-    boxsize = 1.
-    autocorr = 1
-    r_bins = [0.2, 0.3, 0.4]
-    if N == 2:
-        pos = np.array([[0., 0.],
-                        [0., 0.],
-                        [0., 0.35],
-                        ])
-    else:
-        raise NotImplemented(N)
-
-    results = DD(autocorr, nthreads, r_bins, pos[0], pos[1], pos[2],
-                 boxsize=boxsize, periodic=True,
-                 verbose=True)
-
-    if N == 2:
-        assert np.all(results['npairs'] == [0, 2])
-
-
-def test_duplicate_cellpairs(isa='fastest', nthreads=maxthreads()):
+@pytest.mark.parametrize('autocorr', [0, 1])
+@pytest.mark.parametrize('binref', [1, 2, 3])
+@pytest.mark.parametrize('min_sep_opt', [False, True])
+@pytest.mark.parametrize('maxcells', [1, 2, 3])
+def test_duplicate_cellpairs(autocorr, binref, min_sep_opt, maxcells,
+                             isa='fastest', nthreads=maxthreads()):
     '''A test to implement Manodeep's example from
     https://github.com/manodeep/Corrfunc/pull/277#issuecomment-1190921894
+    where a particle pair straddles the wrap.
+
+    Also tests the large Rmax case, where Rmax is almost as large as L/2.
     '''
     from Corrfunc.theory import DD
     boxsize = 1.
-    autocorr = 1
-    r_bins = [0.01, 0.1]
+    r_bins = [0.01, 0.4]
     pos = np.array([[0.02, 0.98],
                     [0., 0.],
                     [0., 0.0],
                     ])
 
     results = DD(autocorr, nthreads, r_bins, pos[0], pos[1], pos[2],
+                 X2=pos[0], Y2=pos[1], Z2=pos[2],
                  boxsize=boxsize, periodic=True,
-                 verbose=True)
+                 verbose=True, max_cells_per_dim=maxcells,
+                 xbin_refine_factor=binref, ybin_refine_factor=binref,
+                 zbin_refine_factor=binref, enable_min_sep_opt=min_sep_opt,
+                 )
 
     assert np.all(results['npairs'] == [2])
 
-    autocorr = 0
+    r_bins = [0.2, 0.3, 0.49]
+    pos = np.array([[0., 0.],
+                    [0., 0.],
+                    [0., 0.48],
+                    ])
+
     results = DD(autocorr, nthreads, r_bins, pos[0], pos[1], pos[2],
                  X2=pos[0], Y2=pos[1], Z2=pos[2],
                  boxsize=boxsize, periodic=True,
-                 verbose=True)
+                 verbose=True, max_cells_per_dim=maxcells,
+                 xbin_refine_factor=binref, ybin_refine_factor=binref,
+                 zbin_refine_factor=binref, enable_min_sep_opt=min_sep_opt,
+                 )
 
-    assert np.all(results['npairs'] == [2])
+    assert np.all(results['npairs'] == [0, 2])
 
 
 

--- a/Corrfunc/tests/test_theory.py
+++ b/Corrfunc/tests/test_theory.py
@@ -144,12 +144,12 @@ def test_duplicate_cellpairs(autocorr, binref, min_sep_opt, maxcells,
     Also tests the large Rmax case, where Rmax is almost as large as L/2.
     '''
     from Corrfunc.theory import DD
-    boxsize = 1.
-    r_bins = [0.01, 0.4]
+    boxsize = 432.
+    r_bins = np.array([0.01, 0.4]) * boxsize
     pos = np.array([[0.02, 0.98],
                     [0., 0.],
                     [0., 0.0],
-                    ])
+                    ]) * boxsize
 
     results = DD(autocorr, nthreads, r_bins, pos[0], pos[1], pos[2],
                  X2=pos[0], Y2=pos[1], Z2=pos[2],
@@ -161,11 +161,11 @@ def test_duplicate_cellpairs(autocorr, binref, min_sep_opt, maxcells,
 
     assert np.all(results['npairs'] == [2])
 
-    r_bins = [0.2, 0.3, 0.49]
+    r_bins = np.array([0.2, 0.3, 0.49]) * boxsize
     pos = np.array([[0., 0.],
                     [0., 0.],
                     [0., 0.48],
-                    ])
+                    ]) * boxsize
 
     results = DD(autocorr, nthreads, r_bins, pos[0], pos[1], pos[2],
                  X2=pos[0], Y2=pos[1], Z2=pos[2],
@@ -205,7 +205,6 @@ def test_rmax_against_brute(autocorr, binref, min_sep_opt, maxcells,
     pdiff[pdiff >= boxsize/2] -= boxsize
     pdiff = (pdiff**2).sum(axis=0).reshape(-1)
     brutecounts, _ = np.histogram(pdiff, bins=bins**2)
-    print(brutecounts)
 
     # spot-check that we have non-zero counts
     assert np.any(brutecounts > 0)

--- a/Corrfunc/tests/test_theory.py
+++ b/Corrfunc/tests/test_theory.py
@@ -131,6 +131,31 @@ def test_narrow_extent(N, isa='fastest', nthreads=maxthreads()):
         assert np.all(results['npairs'] == [0, 0])
 
 
+@pytest.mark.parametrize('N', [2])
+def test_large_Rmax(N, isa='fastest', nthreads=maxthreads()):
+    '''Test that an Rmax comparable to the boxsize gives the right answer
+    '''
+    from Corrfunc.theory import DD
+    boxsize = 1.
+    autocorr = 1
+    r_bins = [0.2, 0.3, 0.4]
+    if N == 2:
+        pos = np.array([[0., 0.],
+                        [0., 0.],
+                        [0., 0.35],
+                        ])
+    else:
+        raise NotImplemented(N)
+
+    results = DD(autocorr, nthreads, r_bins, pos[0], pos[1], pos[2],
+                 boxsize=boxsize, periodic=True,
+                 verbose=True)
+
+    if N == 2:
+        assert np.all(results['npairs'] == [0, 2])
+
+
+
 @pytest.mark.parametrize('isa,nthreads', generate_isa_and_nthreads_combos())
 def test_DDrppi(gals_Mr19, isa, nthreads):
     from Corrfunc.theory import DDrppi

--- a/Corrfunc/tests/test_theory.py
+++ b/Corrfunc/tests/test_theory.py
@@ -209,8 +209,8 @@ def test_rmax_against_brute(autocorr, binref, min_sep_opt, maxcells,
 
     # Compute dist^2 = x^2 + y^2 + z^2, flattening because we don't
     # care which dist came from which particle pair
-    pdiff = (pdiff**2).sum(axis=0).reshape(-1)
-    brutecounts, _ = np.histogram(pdiff, bins=bins**2)
+    sqr_pdiff = (pdiff**2).sum(axis=0).reshape(-1)
+    brutecounts, _ = np.histogram(sqr_pdiff, bins=bins**2)
 
     # spot-check that we have non-zero counts
     assert np.any(brutecounts > 0)

--- a/common.mk
+++ b/common.mk
@@ -347,12 +347,10 @@ ifeq ($(DO_CHECKS), 1)
     CLINK += -lm
   endif #not icc
 
-  # The GNU Assembler (GAS) has an AVX-512 bug in versions 2.30 to 2.31.1
-  # So we turn off AVX-512 if the compiler reports it is using one of these versions.
-  # This works for gcc and icc.
-  # clang typically uses its own assembler, but if it is using the system assembler, this will also detect that.
+  # The GNU Assembler (GAS) has an AVX-512 bug in some versions (originally 2.30 to 2.31.1)
+  # So we compile a test program and check the assembly for the correct output.
   # See: https://github.com/manodeep/Corrfunc/issues/193
-  GAS_BUG_DISABLE_AVX512 := $(shell $(CC) $(CFLAGS) -xc -Wa,-v -c /dev/null -o /dev/null 2>&1 | \grep -Ecm1 'GNU assembler version (2\.30|2\.31|2\.31\.1)')
+  GAS_BUG_DISABLE_AVX512 := $(shell echo 'vmovaps 64(,%rax), %zmm0' | $(CC) $(CFLAGS) -xassembler -c - -oa.out 2>/dev/null && objdump -dw a.out | \grep -q 'vmovaps 0x40(,%rax,1),%zmm0'; RET=$$?; rm -f a.out; echo $$RET)
 
   ifeq ($(GAS_BUG_DISABLE_AVX512),1)
     # Did the compiler support AVX-512 in the first place? Otherwise no need to disable it!

--- a/utils/gridlink_impl.c.src
+++ b/utils/gridlink_impl.c.src
@@ -481,10 +481,10 @@ struct cell_pair_DOUBLE * generate_cell_pairs_DOUBLE(struct cellarray_DOUBLE *la
 
        MS: 23/8/2019
      */
-    const int check_for_duplicate_ngb_cells = ( any_periodic &&
+    const int check_for_duplicate_ngb_cells = 0; /* ( any_periodic &&
                                                 (nmesh_x < (2*xbin_refine_factor + 1) ||
                                                  nmesh_y < (2*ybin_refine_factor + 1) ||
-                                                 nmesh_z < (2*zbin_refine_factor + 1))  ) ? 1:0;
+                                                 nmesh_z < (2*zbin_refine_factor + 1))  ) ? 1:0;*/
     for(int64_t icell=0;icell<totncells;icell++) {
         struct cellarray_DOUBLE *first = &(lattice1[icell]);
         if(first->nelements == 0) continue;

--- a/utils/gridlink_impl.c.src
+++ b/utils/gridlink_impl.c.src
@@ -453,7 +453,7 @@ struct cell_pair_DOUBLE * generate_cell_pairs_DOUBLE(struct cellarray_DOUBLE *la
     const int64_t nz_ngb = 2*zbin_refine_factor + 1;
     const int64_t max_ngb_cells = nx_ngb * ny_ngb * nz_ngb - 1; // -1 for self
     
-    const int any_periodic = periodic_x || periodic_y || periodic_z;
+    //const int any_periodic = periodic_x || periodic_y || periodic_z;
 
     if( ! (autocorr == 0 || autocorr == 1) ) {
         fprintf(stderr,"Error: Strange value of autocorr = %d. Expected to receive either 1 (auto-correlations) or 0 (cross-correlations)\n", autocorr);

--- a/utils/gridlink_impl.c.src
+++ b/utils/gridlink_impl.c.src
@@ -453,14 +453,14 @@ struct cell_pair_DOUBLE * generate_cell_pairs_DOUBLE(struct cellarray_DOUBLE *la
     const int64_t nz_ngb = 2*zbin_refine_factor + 1;
     const int64_t max_ngb_cells = nx_ngb * ny_ngb * nz_ngb - 1; // -1 for self
     
-    //const int any_periodic = periodic_x || periodic_y || periodic_z;
+    const int any_periodic = periodic_x || periodic_y || periodic_z;
 
     if( ! (autocorr == 0 || autocorr == 1) ) {
         fprintf(stderr,"Error: Strange value of autocorr = %d. Expected to receive either 1 (auto-correlations) or 0 (cross-correlations)\n", autocorr);
         return NULL;
     }
     const int64_t num_self_pairs = totncells;
-    const int64_t num_nonself_pairs = totncells * max_ngb_cells / (1 + autocorr);
+    const int64_t num_nonself_pairs = totncells * max_ngb_cells;
 
     const int64_t max_num_cell_pairs = num_self_pairs + num_nonself_pairs;
     int64_t num_cell_pairs = 0;
@@ -481,10 +481,10 @@ struct cell_pair_DOUBLE * generate_cell_pairs_DOUBLE(struct cellarray_DOUBLE *la
 
        MS: 23/8/2019
      */
-    const int check_for_duplicate_ngb_cells = 0; /* ( any_periodic &&
+    const int check_for_duplicate_ngb_cells = ( any_periodic &&
                                                 (nmesh_x < (2*xbin_refine_factor + 1) ||
                                                  nmesh_y < (2*ybin_refine_factor + 1) ||
-                                                 nmesh_z < (2*zbin_refine_factor + 1))  ) ? 1:0;*/
+                                                 nmesh_z < (2*zbin_refine_factor + 1))  ) ? 1:0;
     for(int64_t icell=0;icell<totncells;icell++) {
         struct cellarray_DOUBLE *first = &(lattice1[icell]);
         if(first->nelements == 0) continue;
@@ -529,7 +529,7 @@ struct cell_pair_DOUBLE * generate_cell_pairs_DOUBLE(struct cellarray_DOUBLE *la
                     //Check if the ngb-cell has already been added - can happen under periodic boundary
                     //conditions, with small value of nmesh_x/y/z (ie large Rmax relative to BoxSize)
                     if(check_for_duplicate_ngb_cells) {
-                        CHECK_AND_CONTINUE_FOR_DUPLICATE_NGB_CELLS_DOUBLE(icell, icell2, num_cell_pairs, num_ngb_this_cell, all_cell_pairs);
+                        CHECK_AND_CONTINUE_FOR_DUPLICATE_NGB_CELLS_DOUBLE(icell, icell2, off_xwrap, off_ywrap, off_zwrap, num_cell_pairs, num_ngb_this_cell, all_cell_pairs);
                     }
 
                     struct cellarray_DOUBLE *second = &(lattice2[icell2]);

--- a/utils/gridlink_mocks_impl.c.src
+++ b/utils/gridlink_mocks_impl.c.src
@@ -1585,7 +1585,12 @@ struct cell_pair_DOUBLE * generate_cell_pairs_mocks_theta_ra_dec_DOUBLE(cellarra
                         continue;
                     }
 
-                    CHECK_AND_CONTINUE_FOR_DUPLICATE_NGB_CELLS_DOUBLE(icell, icell2, num_cell_pairs, num_ngb_this_cell, all_cell_pairs);
+                    // No periodicity with mocks; wrap value is always zero.
+                    DOUBLE xwrap = ZERO;
+                    DOUBLE ywrap = ZERO;
+                    DOUBLE zwrap = ZERO;
+
+                    CHECK_AND_CONTINUE_FOR_DUPLICATE_NGB_CELLS_DOUBLE(icell, icell2, xwrap, ywrap, zwrap, num_cell_pairs, num_ngb_this_cell, all_cell_pairs);
 
                     XRETURN(num_cell_pairs < max_num_cell_pairs, NULL,
                             "Error: Assigning this existing cell-pair would require accessing invalid memory.\n"
@@ -1625,6 +1630,10 @@ struct cell_pair_DOUBLE * generate_cell_pairs_mocks_theta_ra_dec_DOUBLE(cellarra
                     this_cell_pair->closest_x1 = closest_x1;
                     this_cell_pair->closest_y1 = closest_y1;
                     this_cell_pair->closest_z1 = closest_z1;
+
+                    this_cell_pair->xwrap = xwrap;
+                    this_cell_pair->ywrap = ywrap;
+                    this_cell_pair->zwrap = zwrap;
 
                     this_cell_pair->same_cell = (autocorr == 1 && icell2 == icell) ? 1:0;
 

--- a/utils/gridlink_mocks_impl.c.src
+++ b/utils/gridlink_mocks_impl.c.src
@@ -1586,9 +1586,9 @@ struct cell_pair_DOUBLE * generate_cell_pairs_mocks_theta_ra_dec_DOUBLE(cellarra
                     }
 
                     // No periodicity with mocks; wrap value is always zero.
-                    DOUBLE xwrap = ZERO;
-                    DOUBLE ywrap = ZERO;
-                    DOUBLE zwrap = ZERO;
+                    const DOUBLE xwrap = ZERO;
+                    const DOUBLE ywrap = ZERO;
+                    const DOUBLE zwrap = ZERO;
 
                     CHECK_AND_CONTINUE_FOR_DUPLICATE_NGB_CELLS_DOUBLE(icell, icell2, xwrap, ywrap, zwrap, num_cell_pairs, num_ngb_this_cell, all_cell_pairs);
 

--- a/utils/gridlink_utils.c.src
+++ b/utils/gridlink_utils.c.src
@@ -50,6 +50,7 @@ int get_binsize_DOUBLE(const DOUBLE xdiff, const DOUBLE xwrap, const DOUBLE rmax
     }*/
 
     if (nmesh>max_ncells)  nmesh=max_ncells;
+    if (nmesh<2)  nmesh=2;  // to avoid forming duplicate cell pairs
     *xbinsize = xdiff/nmesh;
     *nlattice = nmesh;
 

--- a/utils/gridlink_utils.c.src
+++ b/utils/gridlink_utils.c.src
@@ -33,6 +33,13 @@ int get_binsize_DOUBLE(const DOUBLE xdiff, const DOUBLE xwrap, const DOUBLE rmax
 {
     int nmesh=(int)(refine_factor*xdiff/rmax);
     nmesh = nmesh < 1 ? 1:nmesh;
+    
+    if(xwrap > 0 && rmax >= xwrap/2){
+        fprintf(stderr,"%s> ERROR: rmax=%f must be less than half of periodic boxize=%f to avoid double-counting particles\n",
+            __FILE__,rmax,xwrap);
+        return EXIT_FAILURE;
+    }
+
     /*if( xwrap > 0 && ((xdiff + rmax) >= xwrap) ) {
         if (nmesh<(2*refine_factor+1))  {
             fprintf(stderr,"%s> ERROR:  nlattice = %d is so small that with periodic wrapping the same cells will be counted twice ....exiting\n",__FILE__,nmesh) ;

--- a/utils/gridlink_utils.c.src
+++ b/utils/gridlink_utils.c.src
@@ -33,14 +33,14 @@ int get_binsize_DOUBLE(const DOUBLE xdiff, const DOUBLE xwrap, const DOUBLE rmax
 {
     int nmesh=(int)(refine_factor*xdiff/rmax);
     nmesh = nmesh < 1 ? 1:nmesh;
-    if( xwrap > 0 && ((xdiff + rmax) >= xwrap) ) {
+    /*if( xwrap > 0 && ((xdiff + rmax) >= xwrap) ) {
         if (nmesh<(2*refine_factor+1))  {
             fprintf(stderr,"%s> ERROR:  nlattice = %d is so small that with periodic wrapping the same cells will be counted twice ....exiting\n",__FILE__,nmesh) ;
             fprintf(stderr,"%s> Please reduce Rmax = %"REAL_FORMAT" to be a smaller fraction of the particle distribution region = %"REAL_FORMAT"\n",
                     __FILE__,rmax, xdiff);
             return EXIT_FAILURE;
         }
-    }
+    }*/
 
     if (nmesh>max_ncells)  nmesh=max_ncells;
     *xbinsize = xdiff/nmesh;

--- a/utils/gridlink_utils.h.src
+++ b/utils/gridlink_utils.h.src
@@ -43,7 +43,7 @@ extern "C" {
                                                                    DOUBLE *sqr_sep_min, DOUBLE *sqr_sep_max);
 
 
-#define CHECK_AND_CONTINUE_FOR_DUPLICATE_NGB_CELLS_DOUBLE(icell, icell2, num_cell_pairs, num_ngb_this_cell, all_cell_pairs) { \
+#define CHECK_AND_CONTINUE_FOR_DUPLICATE_NGB_CELLS_DOUBLE(icell, icell2, off_xwrap, off_ywrap, off_zwrap, num_cell_pairs, num_ngb_this_cell, all_cell_pairs) { \
         int duplicate_flag = 0;                                         \
         XRETURN(num_cell_pairs - num_ngb_this_cell >= 0, NULL,          \
                 "Error: While working on detecting (potential) duplicate cell-pairs on primary cell = %"PRId64"\n" \
@@ -57,7 +57,10 @@ extern "C" {
                     "For cell-pair # %"PRId64", the primary cellindex (within cell-pair) = %"PRId64" should be *exactly* " \
                     "equal to current primary cellindex = %"PRId64". Num_cell_pairs = %"PRId64" num_ngb_this_cell = %"PRId64"\n", \
                     icell, num_cell_pairs - jj, this_cell_pair->cellindex1, icell, num_cell_pairs, num_ngb_this_cell); \
-            if (this_cell_pair->cellindex2 == icell2) {                 \
+            if (this_cell_pair->cellindex2 == icell2 &&                 \
+                this_cell_pair->xwrap == off_xwrap   &&                 \
+                this_cell_pair->ywrap == off_ywrap   &&                 \
+                this_cell_pair->zwrap == off_zwrap) {                   \
                 duplicate_flag = 1;                                     \
                 break;                                                  \
             }                                                           \

--- a/utils/gridlink_utils.h.src
+++ b/utils/gridlink_utils.h.src
@@ -57,6 +57,8 @@ extern "C" {
                     "For cell-pair # %"PRId64", the primary cellindex (within cell-pair) = %"PRId64" should be *exactly* " \
                     "equal to current primary cellindex = %"PRId64". Num_cell_pairs = %"PRId64" num_ngb_this_cell = %"PRId64"\n", \
                     icell, num_cell_pairs - jj, this_cell_pair->cellindex1, icell, num_cell_pairs, num_ngb_this_cell); \
+            _Pragma("GCC diagnostic push")                              \
+            _Pragma("GCC diagnostic ignored \"-Wfloat-equal\"")         \
             if (this_cell_pair->cellindex2 == icell2 &&                 \
                 this_cell_pair->xwrap == off_xwrap   &&                 \
                 this_cell_pair->ywrap == off_ywrap   &&                 \
@@ -64,6 +66,7 @@ extern "C" {
                 duplicate_flag = 1;                                     \
                 break;                                                  \
             }                                                           \
+            _Pragma("GCC diagnostic pop")                               \
         }                                                               \
         if(duplicate_flag == 1) continue;                               \
     }


### PR DESCRIPTION
In looking at the gridlink/cell pair code for #276, I was reminded that we are explicitly computing the offset between pairs of cells e.g. here: https://github.com/manodeep/Corrfunc/blob/c3e260d70888c2cdc9e772b5cd97e59068d2522e/utils/gridlink_impl.c.src#L504

Which made me think: if we know the offset of each cell pair, and that offset is applied in the kernels, then what's the harm in adding duplicate cell pairs? They will *not* find duplicate particle pairs, because a cell pair can be added at most once with a positive offset, and once with a negative.  So as long as we enforce `Rmax < boxsize/2`, there ought not to be duplicate counts.

So allowing duplicate cell pairs, the usual tests seem to be passing (but those have small Rmax). I did add a simple large Rmax test with two particles, which seems to work.

This is also related to the old issue #210. I did test that reproducer, which fails with an "Rmax too large" error in master but succeeds with this PR.

@manodeep Am I missing something? Is there a counterexample where this doesn't work?

This is relatively low priority, but it does relate to the question of the conditions to avoid duplicates in https://github.com/manodeep/Corrfunc/pull/276#issuecomment-1189176506 (or rather, removes that question entirely).