### PR TITLE
Update GNU assembler bug detection

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -24,6 +24,7 @@ Fixes
 -----
 - Add additional check to tell if it's safe to redirect stdout/err [#270]
 - Check and fix ``z`` vs ``cz`` in ``DDrppi_mocks`` and ``DDsmu_mocks`` only if comoving distance flag is not set [#275]
+- Update GNU assembler bug detection [#278]
 
 
 2.4.0 (2021-09-30)


### PR DESCRIPTION
The fix for the GNU assembler bug (#196, https://sourceware.org/bugzilla/show_bug.cgi?id=23465) has been backported (https://bugzilla.redhat.com/show_bug.cgi?id=1869401), so we shouldn't rely on version numbers to detect the presence of the bug. Instead, we should just assemble a micro-program (`vmovaps 64(,%rax), %zmm0`) and check that it produces the correct result.

This will re-enable Corrfunc AVX-512 on some platforms (notably, my desktop at work!).