### PR TITLE
README updates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -147,4 +147,4 @@ jobs:
         shell: bash -l {0}
         run: |
           python -m pip install pytest
-          pytest -v
+          python -m pytest -v

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -25,6 +25,7 @@ Fixes
 - Add additional check to tell if it's safe to redirect stdout/err [#270]
 - Check and fix ``z`` vs ``cz`` in ``DDrppi_mocks`` and ``DDsmu_mocks`` only if comoving distance flag is not set [#275]
 - Update GNU assembler bug detection [#278]
+- Fix installation instructions and update README.rst [#285]
 
 
 2.4.0 (2021-09-30)

--- a/README.rst
+++ b/README.rst
@@ -59,7 +59,8 @@ Method 1: Source Installation (Recommended)
 
 ::
 
-    $ git clone https://github.com/manodeep/Corrfunc/
+    $ git clone https://github.com/manodeep/Corrfunc.git
+    $ cd Corrfunc
     $ make
     $ make install
     $ python -m pip install . [--user]
@@ -73,8 +74,9 @@ Assuming you have ``gcc`` in your ``PATH``, ``make`` and
 extensions within the source directory. If you would like to install the
 CPython extensions in your environment, then
 ``python -m pip install . [--user]`` should be sufficient. If you are primarily
-interested in the ``python`` interface, you can condense all of the steps
-by using ``python -m pip install . [--user] --install-option="CC=yourcompiler"`` after ``git clone``.
+interested in the Python interface, you can condense all of the steps
+by using ``python -m pip install . [--user] --install-option="CC=yourcompiler"``
+after ``git clone [...]`` and ``cd Corrfunc``.
 
 Compilation Notes
 ~~~~~~~~~~~~~~~~~
@@ -86,6 +88,18 @@ Compilation Notes
 - Default compiler on MAC is set to ``clang``, if you want to specify a different compiler, you will have to call ``make CC=yourcompiler``,  ``make install CC=yourcompiler``, ``make tests CC=yourcompiler`` etc. If you want to permanently change the default compiler, then please edit the `common.mk <common.mk>`__ file in the base directory.
 
 - If you are directly using ``python -m pip install . [--user] --install-option="CC=yourcompiler"``, please run a ``make distclean`` beforehand (especially if switching compilers)
+
+- Please note that Corrfunc is compiling with optimizations for the architecture
+it is compiled on.  That is, it uses ``gcc -march=native`` or similar.
+For this reason, please try to compile Corrfunc on the architecture it will
+be run on (usually this is only a concern in heterogeneous compute environments,
+like an HPC cluster with multiple node types).  In many cases, you can
+compile on a more capable architecture (e.g. with AVX-512 support) then
+run on a less capable architecture (e.g. with only AVX2), because the
+runtime dispatch will select the appropriate kernel.  But the non-kernel
+elements of Corrfunc may emit AVX-512 instructions due to ``-march=native``.
+If an ``Illegal instruction`` error occurs, then you'll need to recompile
+on the target architecture.
 
 Installation notes
 ~~~~~~~~~~~~~~~~~~
@@ -105,18 +119,6 @@ pre-requisites, please see the `FAQ <FAQ>`__ or `email
 the Corrfunc mailing list <mailto:corrfunc@googlegroups.com>`__. Also, feel free to create a new issue
 with the ``Installation`` label.
 
-Please note that Corrfunc is compiling with optimizations for the architecture
-it is compiled on.  That is, it uses ``gcc -march=native`` or similar.
-For this reason, please try to compile Corrfunc on the architecture it will
-be run on (usually this is only a concern in heterogeneous compute environments,
-like an HPC cluster with multiple node types).  In many cases, you can
-compile on a more capable architecture (e.g. with AVX-512 support) then
-run on a less capable architecture (e.g. with only AVX2), because the
-runtime dispatch will select the appropriate kernel.  But the non-kernel
-elements of Corrfunc may emit AVX-512 instructions due to ``-march=native``.
-If an ``Illegal instruction`` error occurs, then you'll need to recompile
-on the target architecture.
-
 
 Method 2: pip installation
 --------------------------
@@ -126,6 +128,7 @@ The Python package is directly installable via ``python -m pip install Corrfunc`
 You can check that a pip-installed Corrfunc is working with:
 
 ::
+
    $ python -m Corrfunc.tests
 
 OpenMP on OSX

--- a/README.rst
+++ b/README.rst
@@ -63,11 +63,10 @@ Method 1: Source Installation (Recommended)
     $ make
     $ make install
     $ python -m pip install . [--user]
-    $ make tests
     
-    # optional:
-    $ pip install pytest
-    $ pytest
+    $ make tests  # run the C tests
+    $ python -m pip install pytest
+    $ python -m pytest  # run the Python tests
 
 Assuming you have ``gcc`` in your ``PATH``, ``make`` and
 ``make install`` should compile and install the C libraries + Python
@@ -96,7 +95,7 @@ code is working correctly. Depending on the hardware and compilation
 options, the tests might take more than a few minutes. *Note that the
 tests are exhaustive and not traditional unit tests*.
 
-For Python tests, please run ``pip install pytest`` and ``pytest``
+For Python tests, please run ``python -m pip install pytest`` and ``python -m pytest``
 from the Corrfunc root dir.
 
 While we have tried to ensure that the package compiles and runs out of
@@ -122,15 +121,12 @@ on the target architecture.
 Method 2: pip installation
 --------------------------
 
-The Python package is directly installable via ``pip install Corrfunc``. However, in that case you will lose the ability to recompile the code according to your needs.  This usually fine for a single-machine installation, like a laptop, where you are only using the Python interface.  For usage on a cluster or other environment with multiple CPU architectures, you may find it more useful to use the source installation method above in case you need to compile for a different architecture later.
+The Python package is directly installable via ``python -m pip install Corrfunc``. However, in that case you will lose the ability to recompile the code.  This usually fine if you are only using the Python interface and are on a single machine, like a laptop.  For usage on a cluster or other environment with multiple CPU architectures, you may find it more useful to use the source installation method above in case you need to compile for a different architecture later.
 
-You can test a pip-installed Corrfunc with:
+You can check that a pip-installed Corrfunc is working with:
 
 ::
-   $ pip install pytest
-   $ pytest --pyargs Corrfunc
-
-The tests may take a few minutes to run.
+   $ python -m Corrfunc.tests
 
 OpenMP on OSX
 --------------


### PR DESCRIPTION
I went to the README to fix the erroneous installation instructions reported by @misharash in https://github.com/manodeep/Corrfunc/issues/284 and ended up noticing some other outdated instructions.  So I did a pass on the installation instructions, incorporating many of the lessons we've learned over the last few years.  Hopefully it now reflects current best practices.