### PR TITLE
Skip data-based pytests when data files are absent

### DIFF
--- a/Corrfunc/tests/common.py
+++ b/Corrfunc/tests/common.py
@@ -6,31 +6,43 @@ import pytest
 
 from Corrfunc.io import read_fastfood_catalog
 
+NO_DATA_SKIP_MESSAGE = "Data files for data-based tests not found. " \
+    "Install from source to enable these tests."
+
+
 @pytest.fixture(scope='module')
 def gals_Mr19():
-    
     filename = pjoin(dirname(abspath(__file__)),
-                    "../../theory/tests/data", "gals_Mr19.ff")
-    x, y, z, w = read_fastfood_catalog(filename, need_weights=True)
-    
+                     "../../theory/tests/data", "gals_Mr19.ff")
+    try:
+        x, y, z, w = read_fastfood_catalog(filename, need_weights=True)
+    except OSError:
+        pytest.skip(NO_DATA_SKIP_MESSAGE)
+
     return x, y, z, w
 
 
 @pytest.fixture(scope='module')
 def Mr19_mock_northonly():
     filename = pjoin(dirname(abspath(__file__)),
-                "../../mocks/tests/data", "Mr19_mock_northonly.rdcz.ff")
-    ra,dec,cz,w = read_fastfood_catalog(filename, need_weights=True)
-    
+                     "../../mocks/tests/data", "Mr19_mock_northonly.rdcz.ff")
+    try:
+        ra, dec, cz, w = read_fastfood_catalog(filename, need_weights=True)
+    except OSError:
+        pytest.skip(NO_DATA_SKIP_MESSAGE)
+
     return ra, dec, cz, w
 
 
 @pytest.fixture(scope='module')
 def Mr19_randoms_northonly():
     filename = pjoin(dirname(abspath(__file__)),
-                "../../mocks/tests/data", "Mr19_randoms_northonly.rdcz.ff")
-    ra,dec,cz,w = read_fastfood_catalog(filename, need_weights=True)
-    
+                     "../../mocks/tests/data", "Mr19_randoms_northonly.rdcz.ff")
+    try:
+        ra, dec, cz, w = read_fastfood_catalog(filename, need_weights=True)
+    except OSError:
+        pytest.skip(NO_DATA_SKIP_MESSAGE)
+
     return ra, dec, cz, w
 
 

--- a/README.rst
+++ b/README.rst
@@ -123,13 +123,23 @@ with the ``Installation`` label.
 Method 2: pip installation
 --------------------------
 
-The Python package is directly installable via ``python -m pip install Corrfunc``. However, in that case you will lose the ability to recompile the code.  This usually fine if you are only using the Python interface and are on a single machine, like a laptop.  For usage on a cluster or other environment with multiple CPU architectures, you may find it more useful to use the source installation method above in case you need to compile for a different architecture later.
+The Python package is directly installable via ``python -m pip install Corrfunc``. However, in that case you will lose the ability to recompile the code.  This usually fine if you are only using the Python interface and are on a single machine, like a laptop.  For usage on a cluster or other environment with multiple CPU architectures, you may find it more useful to use the Source Installation method above in case you need to compile for a different architecture later.
+
+Testing a pip-installed Corrfunc
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 You can check that a pip-installed Corrfunc is working with:
 
 ::
 
-   $ python -m Corrfunc.tests
+   $ python -m pytest --pyargs Corrfunc
+
+
+The pip installation does not include all of the test data contained in the main repo,
+since it would total over 100 MB and the tests that generate on-the-fly data are similarly
+exhaustive.  pytest will mark tests where the data files are not availabe as "skipped".
+If you would like to run the data-based tests, please use the Source Installation method.
+
 
 OpenMP on OSX
 --------------


### PR DESCRIPTION
Since we don't want to be distributing many MB of test data files with the PyPI package, we want pytest to skip any tests that rely on these files if they are absent.  pytest lets us call `pytest.skip(reason)` from within the fixtures where we load the data files, providing a clean solution.  The user will see skipped tests, and the reason they are skipped if verbose output is enabled.

Also, the readme is updated with the correct test instructions for a pip-based installation.
