### PR TITLE
Remove mistaken references to "projected" correlation function in docs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,7 +66,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Setup Miniconda
         uses: conda-incubator/setup-miniconda@v2

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -31,6 +31,7 @@ Fixes
 - Check and fix ``z`` vs ``cz`` in ``DDrppi_mocks`` and ``DDsmu_mocks`` only if comoving distance flag is not set [#275]
 - Update GNU assembler bug detection [#278]
 - Fix installation instructions and update README.rst [#285]
+- Remove mistaken references to "projected" correlation function in docs [#289]
 
 
 2.4.0 (2021-09-30)

--- a/Corrfunc/mocks/DDrppi_mocks.py
+++ b/Corrfunc/mocks/DDrppi_mocks.py
@@ -25,7 +25,7 @@ def DDrppi_mocks(autocorr, cosmology, nthreads, pimax, binfile,
                  copy_particles=True, enable_min_sep_opt=True,
                  c_api_timer=False, isa=r'fastest', weight_type=None):
     """
-    Calculate the 2-D pair-counts corresponding to the projected correlation
+    Calculate the pair-counts corresponding to the 2-D correlation
     function, :math:`\\xi(r_p, \\pi)`. Pairs which are separated by less
     than the ``rp`` bins (specified in ``binfile``) in the
     X-Y plane, and less than ``pimax`` in the Z-dimension are

--- a/Corrfunc/mocks/DDsmu_mocks.py
+++ b/Corrfunc/mocks/DDsmu_mocks.py
@@ -24,7 +24,7 @@ def DDsmu_mocks(autocorr, cosmology, nthreads, mu_max, nmu_bins, binfile,
                 copy_particles=True, enable_min_sep_opt=True,
                 c_api_timer=False, isa='fastest', weight_type=None):
     """
-    Calculate the 2-D pair-counts corresponding to the projected correlation
+    Calculate the 2-D pair-counts corresponding to the correlation
     function, :math:`\\xi(s, \\mu)`. The pairs are counted in bins of
     radial separation and cosine of angle to the line-of-sight (LOS). The
     input positions are expected to be on-sky co-ordinates. This module is

--- a/Corrfunc/theory/xi.py
+++ b/Corrfunc/theory/xi.py
@@ -22,7 +22,7 @@ def xi(boxsize, nthreads, binfile, X, Y, Z,
        copy_particles=True, enable_min_sep_opt=True,
        c_api_timer=False, isa=r'fastest'):
     """
-    Function to compute the projected correlation function in a
+    Function to compute the correlation function in a
     periodic cosmological box. Pairs which are separated by less
     than the ``r`` bins (specified in ``binfile``) in 3-D real space.
 
@@ -186,7 +186,7 @@ def xi(boxsize, nthreads, binfile, X, Y, Z,
     try:
         from Corrfunc._countpairs import countpairs_xi as xi_extn
     except ImportError:
-        msg = "Could not import the C extension for the projected "\
+        msg = "Could not import the C extension for the "\
               "correlation function."
         raise ImportError(msg)
 

--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -14,7 +14,7 @@ The simplest way to install the latest release of the code is with pip. Before i
 
 .. code:: python
 
-    pip install Corrfunc
+    python -m pip install Corrfunc
 
 This will install the latest official release of the code.
 If you want the latest master branch,

--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -14,7 +14,7 @@ The simplest way to install the latest release of the code is with pip. Before i
 
 .. code:: python
 
-          pip install Corrfunc
+    pip install Corrfunc
 
 This will install the latest official release of the code.
 If you want the latest master branch,
@@ -31,10 +31,10 @@ The first step is to clone the Corrfunc repository
 
 .. code::
 
-	  git clone https://github.com/manodeep/Corrfunc.git
-	  cd Corrfunc
-          make install
-          python -m pip install . (--user)
+      git clone https://github.com/manodeep/Corrfunc.git
+      cd Corrfunc
+      make install
+      python -m pip install . (--user)
 
 
 .. _corrfunc_dependencies:
@@ -64,17 +64,20 @@ Verifying your installation
 
 After installing Corrfunc, you should run the integrated test suite to make
 sure that the package was installed correctly. If you installed from source,
-then type the following in the root package directory,
+then run the following sequence from the repository root directory:
 
-.. code::
+.. code:: console
 
-	  make tests
+    make tests  # run the C tests
+    python -m pip install pytest
+    python -m pytest  # run the Python tests
 
 If you installed using pip/conda, then use the following to run the tests
+from your shell:
 
-.. code:: python
+.. code:: console
 
-          from Corrfunc.tests import tests
-          tests()
+    python -m pytest --pyargs Corrfunc
+          
 
 Once you have installed the package, see :ref:`quickstart` for instructions on how to get up and running.

--- a/theory/python_bindings/_countpairs.c
+++ b/theory/python_bindings/_countpairs.c
@@ -526,7 +526,7 @@ static PyMethodDef module_methods[] = {
      "              zbin_refine_factor=1, max_cells_per_dim=100, copy_particles=True,\n"
      "              enable_min_sep_opt=True, c_api_timer=False, isa=-1)\n\n"
 
-     "Function to compute the projected correlation function in a periodic\n"
+     "Function to compute the correlation function in a periodic\n"
      "cosmological box. Pairs which are separated by less than the ``r``\n"
      "bins (specified in ``binfile``). *Always* uses ``PERIODIC`` boundary conditions.\n\n"
 
@@ -625,7 +625,7 @@ static PyMethodDef module_methods[] = {
      "results : A python list\n"
      "    A python list containing [rmin, rmax, ravg, weightavg, xi, npairs] for each radial\n"
      "    bin specified in the ``binfile``. If ``output_ravg`` is not set then\n"
-     "    ``ravg`` will be set to 0.0 for all bins; similarly for ``weightavg``. ``xi`` contains the projected\n"
+     "    ``ravg`` will be set to 0.0 for all bins; similarly for ``weightavg``. ``xi`` contains the\n"
      "    correlation function while ``npairs`` contains the number of unique pairs\n"
      "    in that bin.  If weights are used, then ``xi`` is weighted, while ``npairs`` is not.\n\n"
 

--- a/theory/wp/wp_kernels.c.src
+++ b/theory/wp/wp_kernels.c.src
@@ -277,10 +277,14 @@ static inline int wp_avx512_intrinsics_DOUBLE(DOUBLE *x0, DOUBLE *y0, DOUBLE *z0
             } //OUTPUT_RPAVG
         }//end of j-loop over second set of particles
     }//loop over first set of particles
-    
+
+#ifdef COUNT_VECTORIZED
     uint64_t npairs_found = 0;
+#endif  
     for(int i=0;i<nbin;i++) {
+#ifdef COUNT_VECTORIZED
         npairs_found += npairs[i];
+#endif  
         src_npairs[i] += npairs[i];
         if(need_rpavg) {
             src_rpavg[i]  += rpavg[i];
@@ -618,9 +622,13 @@ static inline int wp_avx2_intrinsics_DOUBLE(DOUBLE *x0, DOUBLE *y0, DOUBLE *z0, 
         }//remainder loop over second set of particles
     }//loop over first set of particles
     
+#ifdef COUNT_VECTORIZED
     uint64_t npairs_found = 0;
+#endif  
     for(int i=0;i<nbin;i++) {
+#ifdef COUNT_VECTORIZED
         npairs_found += npairs[i];
+#endif  
         src_npairs[i] += npairs[i];
         if(need_rpavg) {
             src_rpavg[i]  += rpavg[i];
@@ -972,9 +980,13 @@ static inline int wp_avx_intrinsics_DOUBLE(DOUBLE *x0, DOUBLE *y0, DOUBLE *z0, c
         }//remainder loop over second set of particles
     }//loop over first set of particles
 
+#ifdef COUNT_VECTORIZED
     uint64_t npairs_found = 0;
+#endif  
     for(int i=0;i<nbin;i++) {
+#ifdef COUNT_VECTORIZED
         npairs_found += npairs[i];
+#endif  
         src_npairs[i] += npairs[i];
         if(need_rpavg) {
             src_rpavg[i]  += rpavg[i];
@@ -1306,10 +1318,15 @@ static inline int wp_sse_intrinsics_DOUBLE(DOUBLE *x0, DOUBLE *y0, DOUBLE *z0, c
             }//searching for kbin loop
         }
     }
+  
+#ifdef COUNT_VECTORIZED
     uint64_t npairs_found = 0;
+#endif  
     for(int i=0;i<nbin;i++) {
-        src_npairs[i] += npairs[i];
+#ifdef COUNT_VECTORIZED
         npairs_found += npairs[i];
+#endif  
+        src_npairs[i] += npairs[i];
         if(need_rpavg) {
             src_rpavg[i] += rpavg[i];
         }
@@ -1499,11 +1516,15 @@ static inline int wp_fallback_DOUBLE(DOUBLE *x0, DOUBLE *y0, DOUBLE *z0, const w
             }//searching for kbin loop                                                               
         }
     }
-    
+
+#ifdef COUNT_VECTORIZED
     uint64_t npairs_found = 0;
+#endif  
     for(int i=0;i<nbin;i++) {
-        src_npairs[i] += npairs[i];
+#ifdef COUNT_VECTORIZED
         npairs_found += npairs[i];
+#endif  
+        src_npairs[i] += npairs[i];
         if(need_rpavg) {
             src_rpavg[i] += rpavg[i];
         }


### PR DESCRIPTION
Also update test instructions on RTD.  From #288.