### PR TITLE
mocks: warn about small theta and large mu in float32 precision

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -20,7 +20,7 @@ Changes
 
 Enhancements
 ------------
-- mocks: warn about small theta and large mu in float32 precision [#299]
+- Warn about loss of precision for float32 calculations involving small ``theta`` in ``DDtheta_mocks`` and large ``mu`` in ``DDsmu_mocks`` [#299]
 
 2.5.0 (2022-12-23)
 ================

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -18,6 +18,10 @@ Changes
 -------
 - Python >= 3.7 and numpy >= 1.16 are required for python extensions [#291]
 
+Enhancements
+------------
+- mocks: warn about small theta and large mu in float32 precision [#299]
+
 2.5.0 (2022-12-23)
 ================
 

--- a/Corrfunc/mocks/DDsmu_mocks.py
+++ b/Corrfunc/mocks/DDsmu_mocks.py
@@ -355,7 +355,7 @@ def DDsmu_mocks(autocorr, cosmology, nthreads, mu_max, nmu_bins, binfile,
 def warn_large_mu(mu_max, dtype):
     '''
     Small theta values (large mu) underfloat float32. Warn the user.
-    Context: https://github.com/manodeep/Corrfunc/pull/296 (see also #297)
+    Context: https://github.com/manodeep/Corrfunc/issues/296 (see also #297)
     '''
     if dtype.itemsize > 4:
         return

--- a/Corrfunc/mocks/DDsmu_mocks.py
+++ b/Corrfunc/mocks/DDsmu_mocks.py
@@ -367,7 +367,7 @@ of floating-point precision, as the input data is in float32 precision or
 lower. In float32, the loss of precision is 1% in mu at separations of 0.2
 degrees, and larger at smaller separations.
 For more information, see:
-https://github.com/manodeep/Corrfunc/pull/296 (see also #297)
+https://github.com/manodeep/Corrfunc/issues/296 (see also #297)
 """
                       )
 

--- a/Corrfunc/mocks/DDsmu_mocks.py
+++ b/Corrfunc/mocks/DDsmu_mocks.py
@@ -355,7 +355,7 @@ def DDsmu_mocks(autocorr, cosmology, nthreads, mu_max, nmu_bins, binfile,
 def warn_large_mu(mu_max, dtype):
     '''
     Small theta values (large mu) underfloat float32. Warn the user.
-    Context: https://github.com/manodeep/Corrfunc/pull/297
+    Context: https://github.com/manodeep/Corrfunc/pull/296 (see also #297)
     '''
     if dtype.itemsize > 4:
         return
@@ -366,7 +366,8 @@ Be aware that small angular pair separations (mu near 1) will suffer from loss
 of floating-point precision, as the input data is in float32 precision or
 lower. In float32, the loss of precision is 1% in mu at separations of 0.2
 degrees, and larger at smaller separations.
-For more information, see: https://github.com/manodeep/Corrfunc/pull/297
+For more information, see:
+https://github.com/manodeep/Corrfunc/pull/296 (see also #297)
 """
                       )
 

--- a/Corrfunc/mocks/DDtheta_mocks.py
+++ b/Corrfunc/mocks/DDtheta_mocks.py
@@ -653,7 +653,7 @@ def find_fastest_DDtheta_mocks_bin_refs(autocorr, nthreads, binfile,
 def warn_small_theta(thetabinfile, dtype):
     '''
     Small theta values underfloat float32. Warn the user.
-    Context: https://github.com/manodeep/Corrfunc/pull/297
+    Context: https://github.com/manodeep/Corrfunc/pull/296 (see also #297)
     '''
     if dtype.itemsize > 4:
         return
@@ -667,7 +667,8 @@ Could not load binfile "{}". Be aware that small angular pair separations
 will suffer from loss of floating-point precision, as the input data is in
 float32 precision or lower. The loss of precision is 0.5% in theta at
 separations of 0.2 degrees, and larger at smaller separations.
-For more information, see: https://github.com/manodeep/Corrfunc/pull/297
+For more information, see:
+https://github.com/manodeep/Corrfunc/pull/296 (see also #297)
 """.format(thetabinfile)
                       )
         return
@@ -679,7 +680,8 @@ requested, and the input data is in float32 precision or lower. Be aware that
 small angular pair separations will suffer from loss of floating-point
 precision. In float32, the loss of precision is 0.5% in theta at separations of
 0.2 degrees, and larger at smaller separations.
-For more information, see: https://github.com/manodeep/Corrfunc/pull/297
+For more information, see:
+https://github.com/manodeep/Corrfunc/pull/296 (see also #297)
 """
                       )
 

--- a/Corrfunc/mocks/DDtheta_mocks.py
+++ b/Corrfunc/mocks/DDtheta_mocks.py
@@ -653,7 +653,7 @@ def find_fastest_DDtheta_mocks_bin_refs(autocorr, nthreads, binfile,
 def warn_small_theta(thetabinfile, dtype):
     '''
     Small theta values underfloat float32. Warn the user.
-    Context: https://github.com/manodeep/Corrfunc/pull/296 (see also #297)
+    Context: https://github.com/manodeep/Corrfunc/issues/296 (see also #297)
     '''
     if dtype.itemsize > 4:
         return

--- a/Corrfunc/mocks/DDtheta_mocks.py
+++ b/Corrfunc/mocks/DDtheta_mocks.py
@@ -668,7 +668,7 @@ will suffer from loss of floating-point precision, as the input data is in
 float32 precision or lower. The loss of precision is 0.5% in theta at
 separations of 0.2 degrees, and larger at smaller separations.
 For more information, see:
-https://github.com/manodeep/Corrfunc/pull/296 (see also #297)
+https://github.com/manodeep/Corrfunc/issues/296 (see also #297)
 """.format(thetabinfile)
                       )
         return
@@ -681,7 +681,7 @@ small angular pair separations will suffer from loss of floating-point
 precision. In float32, the loss of precision is 0.5% in theta at separations of
 0.2 degrees, and larger at smaller separations.
 For more information, see:
-https://github.com/manodeep/Corrfunc/pull/296 (see also #297)
+https://github.com/manodeep/Corrfunc/issues/296 (see also #297)
 """
                       )
 

--- a/Corrfunc/mocks/DDtheta_mocks.py
+++ b/Corrfunc/mocks/DDtheta_mocks.py
@@ -10,6 +10,7 @@ Python wrapper around the C extension for the angular correlation function
 
 from __future__ import (division, print_function, absolute_import,
                         unicode_literals)
+import warnings
 
 __author__ = ('Manodeep Sinha', 'Kris Akira Stern')
 __all__ = ('DDtheta_mocks', 'find_fastest_DDtheta_mocks_bin_refs')
@@ -313,6 +314,11 @@ def DDtheta_mocks(autocorr, nthreads, binfile,
 
     integer_isa = translate_isa_string_to_enum(isa)
     rbinfile, delete_after_use = return_file_with_rbins(binfile)
+
+    warn_small_theta(rbinfile,
+                     RA1.dtype,  # RA and DEC are checked to be the same dtype
+                     )
+
     with sys_pipes():
         extn_results = DDtheta_mocks_extn(autocorr, nthreads, rbinfile,
                                           RA1, DEC1,
@@ -642,6 +648,40 @@ def find_fastest_DDtheta_mocks_bin_refs(autocorr, nthreads, binfile,
             ret += (all_runtimes,)
 
     return ret
+
+
+def warn_small_theta(thetabinfile, dtype):
+    '''
+    Small theta values underfloat float32. Warn the user.
+    Context: https://github.com/manodeep/Corrfunc/pull/297
+    '''
+    if dtype.itemsize > 4:
+        return
+
+    import numpy as np
+    try:
+        bins = np.loadtxt(thetabinfile)
+    except RuntimeError:
+        warnings.warn("""
+Could not load binfile "{}". Be aware that small angular pair separations
+will suffer from loss of floating-point precision, as the input data is in
+float32 precision or lower. The loss of precision is 0.5% in theta at
+separations of 0.2 degrees, and larger at smaller separations.
+For more information, see: https://github.com/manodeep/Corrfunc/pull/297
+""".format(thetabinfile)
+                      )
+        return
+
+    if bins.min() <= 0.2:
+        warnings.warn("""
+A binning with a minimum angular separation of 0.2 degrees or less was
+requested, and the input data is in float32 precision or lower. Be aware that
+small angular pair separations will suffer from loss of floating-point
+precision. In float32, the loss of precision is 0.5% in theta at separations of
+0.2 degrees, and larger at smaller separations.
+For more information, see: https://github.com/manodeep/Corrfunc/pull/297
+"""
+                      )
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
From https://github.com/manodeep/Corrfunc/pull/297#issuecomment-1605773449.

Not sure if we should include the mu warning; a user is unlikely to be splitting hairs about the exact mu value above 0.98 like they would small theta. @manodeep what do you think?