### PR TITLE
Fix python_requires in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -560,7 +560,7 @@ def setup_packages():
                                                       min_np_minor),
                               'future',
                               'wurlitzer'],
-            python_requires='>=2.7,!=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, !=3.5.*, !=3.6.*,, <4',
+            python_requires='>=2.7,!=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, !=3.5.*, !=3.6.*, <4',
             zip_safe=False,
             cmdclass={'build_ext': BuildExtSubclass})
 


### PR DESCRIPTION
Fix typo in python version constraint leading to

```python
   5  ~/.local/share/pypoetry/venv/lib/python3.9/site-packages/poetry/puzzle/provider.py:352 in _search_for_vcs
        350│         and get the information we need by checking out the specified reference.
        351│         """
     →  352│         package = self.get_package_from_vcs(
        353│             dependency.vcs,
        354│             dependency.source,

   4  ~/.local/share/pypoetry/venv/lib/python3.9/site-packages/poetry/puzzle/provider.py:382 in get_package_from_vcs
        380│             raise ValueError(f"Unsupported VCS dependency {vcs}")
        381│ 
     →  382│         return _get_package_from_git(
        383│             url=url,
        384│             branch=branch,

   3  ~/.local/share/pypoetry/venv/lib/python3.9/site-packages/poetry/puzzle/provider.py:124 in _get_package_from_git
        122│         path = path.joinpath(subdirectory)
        123│ 
     →  124│     package = Provider.get_package_from_directory(path)
        125│     package._source_type = "git"
        126│     package._source_url = url

   2  ~/.local/share/pypoetry/venv/lib/python3.9/site-packages/poetry/puzzle/provider.py:435 in get_package_from_directory
        433│     @classmethod
        434│     def get_package_from_directory(cls, directory: Path) -> Package:
     →  435│         return PackageInfo.from_directory(path=directory).to_package(root_dir=directory)
        436│ 
        437│     def _search_for_url(self, dependency: URLDependency) -> Package:

   1  ~/.local/share/pypoetry/venv/lib/python3.9/site-packages/poetry/inspection/info.py:175 in to_package
       173│             package.description = self.summary
       174│         package.root_dir = root_dir
     → 175│         package.python_versions = self.requires_python or "*"
       176│         package.files = self.files
       177│ 

  ParseConstraintError

  Invalid python versions '>=2.7,!=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, !=3.5.*, !=3.6.*,, <4' on corrfunc (2.5.1 /home/cbyrohl/.cache/pypoetry/virtualenvs/cosmostng-xIqqQ-4m-py3.9/src/Corrfunc)

```
