### PR TITLE
Simplifying fallback kernels

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -13,7 +13,8 @@ New features
 2.5.2 (upcoming)
 ================
 - Fix python_requires in setup.py [#302]
-
+- Faster `FALLBACK` kernels [#303]
+  
 2.5.1 (28/07/2023)
 ==================
 

--- a/mocks/DDrppi_mocks/countpairs_rp_pi_mocks_kernels.c.src
+++ b/mocks/DDrppi_mocks/countpairs_rp_pi_mocks_kernels.c.src
@@ -1130,8 +1130,8 @@ static inline int countpairs_rp_pi_mocks_fallback_DOUBLE(const int64_t N0, DOUBL
                                                          const DOUBLE min_xdiff, const DOUBLE min_ydiff, const DOUBLE min_zdiff,
                                                          const DOUBLE closest_icell_xpos, const DOUBLE closest_icell_ypos,
                                                          const DOUBLE closest_icell_zpos,
-                                                         DOUBLE *src_rpavg, uint64_t *src_npairs,
-                                                         DOUBLE *src_weightavg, const weight_method_t weight_method)
+                                                         DOUBLE *restrict src_rpavg, uint64_t *restrict src_npairs,
+                                                         DOUBLE *restrict src_weightavg, const weight_method_t weight_method)
 {
     if(N0 == 0 || N1 == 0) {
         return EXIT_SUCCESS;
@@ -1141,39 +1141,16 @@ static inline int countpairs_rp_pi_mocks_fallback_DOUBLE(const int64_t N0, DOUBL
         return EXIT_FAILURE;
     }
 
-    const int32_t need_rpavg = src_rpavg != NULL;
-    const int32_t need_weightavg = src_weightavg != NULL;
-
     (void) fast_divide_and_NR_steps;//unused parameter but required to keep the same function signature amongst the kernels
 
     /*----------------- FALLBACK CODE --------------------*/
-    const int64_t totnbins = (npibin+1)*(nbin+1);
     const DOUBLE sqr_pimax = pimax*pimax;
     const DOUBLE sqr_max_sep = sqr_rpmax + sqr_pimax;
 
-    uint64_t npairs[totnbins];
-    DOUBLE rpavg[totnbins], weightavg[totnbins];
-    for(int i=0;i<totnbins;i++) {
-        npairs[i] = 0;
-        if(need_rpavg) {
-            rpavg[i]=ZERO;
-        }
-        if(need_weightavg){
-            weightavg[i]=ZERO;
-        }
-    }
-
-    // A copy whose pointers we can advance
-    weight_struct_DOUBLE local_w0 = {.weights={NULL}, .num_weights=0}, local_w1 = {.weights={NULL}, .num_weights=0};
     pair_struct_DOUBLE pair = {.num_weights=0};
     weight_func_t_DOUBLE weight_func = NULL;
-    if(need_weightavg){
-        // Same particle list, new copy of num_weights pointers into that list
-        local_w0 = *weights0;
-        local_w1 = *weights1;
-
-        pair.num_weights = local_w0.num_weights;
-
+    if(src_weightavg != NULL){
+        pair.num_weights = weights0->num_weights;
         weight_func = get_weight_func_by_method_DOUBLE(weight_method);
     }
 
@@ -1187,7 +1164,7 @@ static inline int countpairs_rp_pi_mocks_fallback_DOUBLE(const int64_t N0, DOUBL
         const DOUBLE ypos = *y0++;
         const DOUBLE zpos = *z0++;
         for(int w = 0; w < pair.num_weights; w++){
-            pair.weights0[w].d = *local_w0.weights[w]++;
+            pair.weights0[w].d = *(weights0->weights[w] + i);
         }
         DOUBLE max_dz = max_all_dz;
 
@@ -1249,9 +1226,6 @@ static inline int countpairs_rp_pi_mocks_fallback_DOUBLE(const int64_t N0, DOUBL
         const int64_t n_off = localz1 - zstart;
         DOUBLE *localx1 = x1 + n_off;
         DOUBLE *localy1 = y1 + n_off;
-        for(int w = 0; w < local_w1.num_weights; w++){
-            local_w1.weights[w] = weights1->weights[w] + n_off;
-        }
 
         const int64_t nleft = N1 - n_off;
         for(int64_t j=0;j<nleft;j++){
@@ -1262,10 +1236,6 @@ static inline int countpairs_rp_pi_mocks_fallback_DOUBLE(const int64_t N0, DOUBL
             const DOUBLE perpx = *localx1++ - xpos;
             const DOUBLE perpy = *localy1++ - ypos;
             const DOUBLE perpz = *localz1++ - zpos;
-
-            for(int w = 0; w < pair.num_weights; w++){
-                pair.weights1[w].d = *local_w1.weights[w]++;
-            }
 
             /* particles are sorted on z, all future j particles will have larger value in localz1 -> perpz will be
                larger. therefore, if current perpz >= max_dz, all future iterations will also be larger. we can
@@ -1288,10 +1258,13 @@ static inline int countpairs_rp_pi_mocks_fallback_DOUBLE(const int64_t N0, DOUBL
             if(sqr_Dperp >= sqr_rpmax || sqr_Dperp < sqr_rpmin) continue;
 
             DOUBLE rp = ZERO, pairweight = ZERO;
-            if(need_rpavg) {
+            if(src_rpavg != NULL) {
                 rp = SQRT(sqr_Dperp);
             }
-            if(need_weightavg){
+            if(src_weightavg != NULL){
+                for(int w = 0; w < pair.num_weights; w++){
+                    pair.weights1[w].d = *(weights1->weights[w] + n_off + j);
+                }
                 pair.dx.d = perpx;
                 pair.dy.d = perpy;
                 pair.dz.d = perpz;
@@ -1306,12 +1279,12 @@ static inline int countpairs_rp_pi_mocks_fallback_DOUBLE(const int64_t N0, DOUBL
             for(int kbin=nbin-1;kbin>=1;kbin--) {
                 if(sqr_Dperp >= rupp_sqr[kbin-1]) {
                     const int ibin = kbin*(npibin+1) + pibin;
-                    npairs[ibin]++;
-                    if(need_rpavg) {
-                        rpavg[ibin]+=rp;
+                    src_npairs[ibin]++;
+                    if(src_rpavg != NULL) {
+                        src_rpavg[ibin] += rp;
                     }
-                    if(need_weightavg){
-                        weightavg[ibin] += pairweight;
+                    if(src_weightavg != NULL){
+                        src_weightavg[ibin] += pairweight;
                     }
                     break;
                 }
@@ -1319,15 +1292,6 @@ static inline int countpairs_rp_pi_mocks_fallback_DOUBLE(const int64_t N0, DOUBL
         }//j loop over second set of particles
     }//i loop over first set of particles
 
-    for(int i=0;i<totnbins;i++) {
-        src_npairs[i] += npairs[i];
-        if(need_rpavg) {
-            src_rpavg[i] += rpavg[i];
-        }
-        if(need_weightavg){
-            src_weightavg[i] += weightavg[i];
-        }
-    }
 
     return EXIT_SUCCESS;
 }//end of fallback code

--- a/mocks/DDsmu_mocks/countpairs_s_mu_mocks_kernels.c.src
+++ b/mocks/DDsmu_mocks/countpairs_s_mu_mocks_kernels.c.src
@@ -1072,9 +1072,10 @@ static inline int countpairs_s_mu_mocks_fallback_DOUBLE(const int64_t N0, DOUBLE
                                                         const DOUBLE min_xdiff, const DOUBLE min_ydiff, const DOUBLE min_zdiff,
                                                         const DOUBLE closest_icell_xpos, const DOUBLE closest_icell_ypos,
                                                         const DOUBLE closest_icell_zpos,
-                                                        DOUBLE *src_savg, uint64_t *src_npairs,
-                                                        DOUBLE *src_weightavg, const weight_method_t weight_method)
+                                                        DOUBLE *restrict src_savg, uint64_t *restrict src_npairs,
+                                                        DOUBLE *restrict src_weightavg, const weight_method_t weight_method)
 {
+    /*----------------- FALLBACK CODE --------------------*/
     if(N0 == 0 || N1 == 0) {
         return EXIT_SUCCESS;
     }
@@ -1084,39 +1085,15 @@ static inline int countpairs_s_mu_mocks_fallback_DOUBLE(const int64_t N0, DOUBLE
     }
 
     (void) fast_divide_and_NR_steps;//unused parameter but required to keep the same function signature amongst the kernels
-    const int32_t need_savg = src_savg != NULL;
-    const int32_t need_weightavg = src_weightavg != NULL;
 
-    const DOUBLE sqr_mumax = mu_max*mu_max;
-
-    /*----------------- FALLBACK CODE --------------------*/
-    const int64_t totnbins = (nmu_bins+1)*(nsbin+1);
-
-    uint64_t npairs[totnbins];
-    DOUBLE savg[totnbins], weightavg[totnbins];
-    for(int i=0;i<totnbins;i++) {
-        npairs[i] = ZERO;
-        if(need_savg) {
-            savg[i]=ZERO;
-        }
-        if(need_weightavg){
-            weightavg[i]=ZERO;
-        }
-    }
-
-    // A copy whose pointers we can advance
-    weight_struct_DOUBLE local_w0 = {.weights={NULL}, .num_weights=0},
-                         local_w1 = {.weights={NULL}, .num_weights=0};
     pair_struct_DOUBLE pair = {.num_weights=0};
     weight_func_t_DOUBLE weight_func = NULL;
-    if(need_weightavg){
-        // Same particle list, new copy of num_weights pointers into that list
-        local_w0 = *weights0;
-        local_w1 = *weights1;
-        pair.num_weights = local_w0.num_weights;
+    if(src_weightavg != NULL){
+        pair.num_weights = weights0->num_weights;
         weight_func = get_weight_func_by_method_DOUBLE(weight_method);
     }
 
+    const DOUBLE sqr_mumax = mu_max*mu_max;
     const DOUBLE dmu = mu_max/(DOUBLE) nmu_bins;
     const DOUBLE inv_dmu = 1.0/dmu;
 
@@ -1127,7 +1104,7 @@ static inline int countpairs_s_mu_mocks_fallback_DOUBLE(const int64_t N0, DOUBLE
         const DOUBLE ypos = *y0++;
         const DOUBLE zpos = *z0++;
         for(int w = 0; w < pair.num_weights; w++){
-            pair.weights0[w].d = *local_w0.weights[w]++;
+            pair.weights0[w].d = *(weights0->weights[w] + i);
         }
 
         DOUBLE max_dz = max_all_dz;
@@ -1191,9 +1168,6 @@ static inline int countpairs_s_mu_mocks_fallback_DOUBLE(const int64_t N0, DOUBLE
         const int64_t nleft = N1 - n_off;
         DOUBLE *localx1 = x1 + n_off;
         DOUBLE *localy1 = y1 + n_off;
-        for(int w = 0; w < pair.num_weights; w++){
-            local_w1.weights[w] = weights1->weights[w] + n_off;
-        }
 
         for(int64_t j=0;j<nleft;j++){
             const DOUBLE parx = xpos + *localx1;
@@ -1203,10 +1177,6 @@ static inline int countpairs_s_mu_mocks_fallback_DOUBLE(const int64_t N0, DOUBLE
             const DOUBLE perpx = *localx1++ - xpos;
             const DOUBLE perpy = *localy1++ - ypos;
             const DOUBLE perpz = *localz1++ - zpos;
-
-            for(int w = 0; w < pair.num_weights; w++){
-                pair.weights1[w].d = *local_w1.weights[w]++;
-            }
 
             if(perpz >= max_dz) break;
 
@@ -1219,10 +1189,13 @@ static inline int countpairs_s_mu_mocks_fallback_DOUBLE(const int64_t N0, DOUBLE
             const DOUBLE sqr_mu = sqr_s_dot_l/(sqr_l * sqr_s);
             const int mubin  = (sqr_mu >= sqr_mumax) ? nmu_bins:(int) (SQRT(sqr_mu)*inv_dmu);
             DOUBLE s = ZERO, pairweight = ZERO;
-            if(need_savg) {
+            if(src_savg != NULL) {
                 s = SQRT(sqr_s);
             }
-            if(need_weightavg){
+            if(src_weightavg != NULL){
+                for(int w = 0; w < pair.num_weights; w++){
+                    pair.weights1[w].d = *(weights1->weights[w] + n_off + j);
+                }
                 pair.dx.d = perpx;
                 pair.dy.d = perpy;
                 pair.dz.d = perpz;
@@ -1237,28 +1210,18 @@ static inline int countpairs_s_mu_mocks_fallback_DOUBLE(const int64_t N0, DOUBLE
             for(int kbin=nsbin-1;kbin>=1;kbin--) {
                 if(sqr_s >= supp_sqr[kbin-1]) {
                     const int ibin = kbin*(nmu_bins+1) + mubin;
-                    npairs[ibin]++;
-                    if(need_savg) {
-                        savg[ibin]+=s;
+                    src_npairs[ibin]++;
+                    if(src_savg != NULL) {
+                        src_savg[ibin] += s;
                     }
-                    if(need_weightavg){
-                        weightavg[ibin] += pairweight;
+                    if(src_weightavg != NULL){
+                        src_weightavg[ibin] += pairweight;
                     }
                     break;
                 }
             }//finding kbin
         }//j loop over second set of particles
     }//i loop over first set of particles
-
-    for(int i=0;i<totnbins;i++) {
-        src_npairs[i] += npairs[i];
-        if(need_savg) {
-            src_savg[i] += savg[i];
-        }
-        if(need_weightavg){
-            src_weightavg[i] += weightavg[i];
-        }
-    }
 
     return EXIT_SUCCESS;
 }//end of fallback code

--- a/mocks/DDtheta_mocks/countpairs_theta_mocks_kernels.c.src
+++ b/mocks/DDtheta_mocks/countpairs_theta_mocks_kernels.c.src
@@ -31,8 +31,8 @@ static inline int countpairs_theta_mocks_fallback_DOUBLE(const int64_t N0, DOUBL
                                                          const DOUBLE min_xdiff, const DOUBLE min_ydiff,
                                                          const DOUBLE min_zdiff, const DOUBLE closest_icell_xpos,
                                                          const DOUBLE closest_icell_ypos, const DOUBLE closest_icell_zpos,
-                                                         DOUBLE *src_rpavg, uint64_t *src_npairs,
-                                                         DOUBLE *src_weightavg, const weight_method_t weight_method)
+                                                         DOUBLE *restrict src_thetaavg, uint64_t *restrict src_npairs,
+                                                         DOUBLE *restrict src_weightavg, const weight_method_t weight_method)
 {
     if(N0 == 0 || N1 == 0) {
         return EXIT_SUCCESS;
@@ -52,31 +52,10 @@ static inline int countpairs_theta_mocks_fallback_DOUBLE(const int64_t N0, DOUBL
      */
     const DOUBLE sqr_max_chord_sep = ((DOUBLE) 2.0) * (((DOUBLE) 1.0) - costhetamax);
 
-    const int32_t need_rpavg = src_rpavg != NULL;
-    const int32_t need_weightavg = src_weightavg != NULL;
-    uint64_t npairs[nthetabin];
-    DOUBLE thetaavg[nthetabin], weightavg[nthetabin];
-    for(int i=0;i<nthetabin;i++) {
-        npairs[i] = 0;
-        if(need_rpavg) {
-            thetaavg[i] = ZERO;
-        }
-        if(need_weightavg){
-            weightavg[i]=ZERO;
-        }
-    }
-
-    // A copy whose pointers we can advance
-    weight_struct_DOUBLE local_w0 = {.weights={NULL}, .num_weights=0}, local_w1 = {.weights={NULL}, .num_weights=0};
     pair_struct_DOUBLE pair = {.num_weights=0};
     weight_func_t_DOUBLE weight_func = NULL;
-    if(need_weightavg){
-        // Same particle list, new copy of num_weights pointers into that list
-        local_w0 = *weights0;
-        local_w1 = *weights1;
-
-        pair.num_weights = local_w0.num_weights;
-
+    if(src_weightavg != NULL){
+        pair.num_weights = weights0->num_weights;
         weight_func = get_weight_func_by_method_DOUBLE(weight_method);
     }
 
@@ -87,7 +66,7 @@ static inline int countpairs_theta_mocks_fallback_DOUBLE(const int64_t N0, DOUBL
         const DOUBLE ypos = *y0++;
         const DOUBLE zpos = *z0++;
         for(int w = 0; w < pair.num_weights; w++){
-            pair.weights0[w].d = *local_w0.weights[w]++;
+            pair.weights0[w].d = *(weights0->weights[w] + i);
         }
 
         DOUBLE max_dz = max_all_dz;
@@ -152,57 +131,42 @@ static inline int countpairs_theta_mocks_fallback_DOUBLE(const int64_t N0, DOUBL
 
         DOUBLE *localx1 = x1 + n_off;
         DOUBLE *localy1 = y1 + n_off;
-        for(int w = 0; w < pair.num_weights; w++){
-            local_w1.weights[w] = weights1->weights[w] + n_off;
-        }
 
         for(int64_t j=0;j<Nleft;j++) {
             const DOUBLE x2 = *localx1++;
             const DOUBLE y2 = *localy1++;
             const DOUBLE z2 = *localz1++;
 
-            const DOUBLE dx = x2 - xpos;
-            const DOUBLE dy = y2 - ypos;
             const DOUBLE dz = z2 - zpos;
-
-            for(int w = 0; w < pair.num_weights; w++){
-                pair.weights1[w].d = *local_w1.weights[w]++;
-            }
 
             /* particles are sorted on z, all future j particles will have larger value in localz1 -> perpz will be
                larger. therefore, if current perpz >= max_dz, all future iterations will also be larger. we can
                terminate the loop */
             if(dz >= max_dz) break;
 
-            const DOUBLE sqr_chord_sep = dx*dx + dy*dy + dz*dz;
-            if(sqr_chord_sep >= sqr_max_chord_sep) {
-                continue;
-            }
-
-            DOUBLE theta = ZERO, pairweight = ZERO;
-            const DOUBLE one = (DOUBLE) 1.0, half = (DOUBLE) 0.5;
-
-            DOUBLE costheta = (one - half*sqr_chord_sep);
-            /* DOUBLE costheta = x2*xpos + y2*ypos + z2*zpos; */
-            if (costheta < -one) costheta = -one;
-            if (costheta > one) costheta = one;
-
+            DOUBLE costheta = x2*xpos + y2*ypos + z2*zpos;
             if(costheta > costhetamin || costheta <= costhetamax) continue;
 
-            if(need_rpavg) {
+            DOUBLE theta = ZERO;
+            if(src_thetaavg != NULL) {
                 if(order) {
                     theta =  INV_PI_OVER_180*FAST_ACOS(costheta);
                 } else {
                     theta =  INV_PI_OVER_180*ACOS(costheta);
                 }
             }
-            if(need_weightavg){
+
+            DOUBLE pairweight = ZERO;
+            if(src_weightavg != NULL){
                 // These are only used for passing to weights
                 // Too expensive?
+                for(int w = 0; w < pair.num_weights; w++){
+                    pair.weights1[w].d = *(weights1->weights[w] + n_off + j);
+                }
 
                 // perpx
-                pair.dx.d = dx;
-                pair.dy.d = dy;
+                pair.dx.d = x2 - xpos;
+                pair.dy.d = y2 - ypos;
                 pair.dz.d = dz;
 
                 // parx
@@ -215,12 +179,12 @@ static inline int countpairs_theta_mocks_fallback_DOUBLE(const int64_t N0, DOUBL
 
             for(int ibin=nthetabin-1;ibin>=1;ibin--) {
               if(costheta <= costheta_upp[ibin-1]) {
-                  npairs[ibin]++;
-                  if(need_rpavg) {
-                      thetaavg[ibin] += theta;
+                  src_npairs[ibin]++;
+                  if(src_thetaavg != NULL) {
+                      src_thetaavg[ibin] += theta;
                   }
-                  if(need_weightavg){
-                      weightavg[ibin] += pairweight;
+                  if(src_weightavg != NULL){
+                      src_weightavg[ibin] += pairweight;
                   }
                   break;
               }
@@ -228,15 +192,6 @@ static inline int countpairs_theta_mocks_fallback_DOUBLE(const int64_t N0, DOUBL
         }//end of j-loop
     }//i loop
 
-    for(int i=0;i<nthetabin;i++) {
-        src_npairs[i] += npairs[i];
-        if(need_rpavg) {
-            src_rpavg[i] += thetaavg[i];
-        }
-        if(need_weightavg){
-            src_weightavg[i] += weightavg[i];
-        }
-    }
     return EXIT_SUCCESS;
 }
 

--- a/mocks/DDtheta_mocks/countpairs_theta_mocks_kernels.c.src
+++ b/mocks/DDtheta_mocks/countpairs_theta_mocks_kernels.c.src
@@ -211,7 +211,7 @@ static inline int countpairs_theta_mocks_sse_intrinsics_DOUBLE(const int64_t N0,
                                                                 const DOUBLE min_xdiff, const DOUBLE min_ydiff,
                                                                 const DOUBLE min_zdiff, const DOUBLE closest_icell_xpos,
                                                                 const DOUBLE closest_icell_ypos, const DOUBLE closest_icell_zpos,
-                                                                DOUBLE *src_rpavg, uint64_t *src_npairs,
+                                                                DOUBLE *src_thetaavg, uint64_t *src_npairs,
                                                                 DOUBLE *src_weightavg, const weight_method_t weight_method)
 {
     if(N0 == 0 || N1 == 0) {
@@ -232,10 +232,10 @@ static inline int countpairs_theta_mocks_sse_intrinsics_DOUBLE(const int64_t N0,
                                                     min_xdiff, min_ydiff,
                                                     min_zdiff, closest_icell_xpos,
                                                     closest_icell_ypos, closest_icell_zpos,
-                                                    src_rpavg, src_npairs, src_weightavg, weight_method);
+                                                    src_thetaavg, src_npairs, src_weightavg, weight_method);
     }
 
-    const int32_t need_rpavg = src_rpavg != NULL;
+    const int32_t need_thetaavg = src_thetaavg != NULL;
     const int32_t need_weightavg = src_weightavg != NULL;
 
     /* const DOUBLE max_chord_sep = 2.0*SIND(0.5*thetamax); */
@@ -255,10 +255,10 @@ static inline int countpairs_theta_mocks_sse_intrinsics_DOUBLE(const int64_t N0,
     }
 
     SSE_FLOATS m_kbin[nthetabin];
-    if(need_rpavg || need_weightavg) {
+    if(need_thetaavg || need_weightavg) {
         for(int i=0;i<nthetabin;i++) {
             m_kbin[i] = SSE_SET_FLOAT((DOUBLE) i);
-            if(need_rpavg){
+            if(need_thetaavg){
                 thetaavg[i] = ZERO;
             }
             if(need_weightavg){
@@ -410,7 +410,7 @@ static inline int countpairs_theta_mocks_sse_intrinsics_DOUBLE(const int64_t N0,
             }
 
             SSE_FLOATS m_thetabin = SSE_SETZERO_FLOAT();
-            if(need_rpavg) {
+            if(need_thetaavg) {
                 //first do the acos to get the actual angles
                 const SSE_FLOATS m_inv_pi_over_180 = SSE_SET_FLOAT(INV_PI_OVER_180);
                 const SSE_FLOATS m_theta = SSE_ARC_COSINE(m_costheta, order);
@@ -437,7 +437,7 @@ static inline int countpairs_theta_mocks_sse_intrinsics_DOUBLE(const int64_t N0,
                 const SSE_FLOATS m1 = SSE_COMPARE_FLOATS_LE(m_costheta,m_costheta_upp[kbin-1]);
                 const SSE_FLOATS m_bin_mask = SSE_BITWISE_AND(m1,m_mask_left);
                 const int test = SSE_TEST_COMPARISON(m_bin_mask);
-                if(need_rpavg || need_weightavg) {
+                if(need_thetaavg || need_weightavg) {
                     m_thetabin = SSE_BLEND_FLOATS_WITH_MASK(m_thetabin,m_kbin[kbin], m_bin_mask);
                 }
 
@@ -448,14 +448,14 @@ static inline int countpairs_theta_mocks_sse_intrinsics_DOUBLE(const int64_t N0,
                 }
             }
 
-            if(need_rpavg || need_weightavg) {
+            if(need_thetaavg || need_weightavg) {
                 union_rpbin.m_ibin = SSE_TRUNCATE_FLOAT_TO_INT(m_thetabin);
 #if  __INTEL_COMPILER
 #pragma unroll(SSE_NVEC)
 #endif
                 for(int jj=0;jj<SSE_NVEC;jj++) {
                     const int kbin = union_rpbin.ibin[jj];
-                    if(need_rpavg){
+                    if(need_thetaavg){
                         const DOUBLE theta = union_mDperp.Dperp[jj];
                         thetaavg[kbin] += theta;
                     }
@@ -485,7 +485,7 @@ static inline int countpairs_theta_mocks_sse_intrinsics_DOUBLE(const int64_t N0,
                 continue;
             }
             DOUBLE theta = ZERO, pairweight = ZERO;
-            if(need_rpavg) {
+            if(need_thetaavg) {
                 if(order) {
                     theta =  INV_PI_OVER_180*FAST_ACOS(costheta);
                 } else {
@@ -508,7 +508,7 @@ static inline int countpairs_theta_mocks_sse_intrinsics_DOUBLE(const int64_t N0,
             for(int ibin=nthetabin-1;ibin>=1;ibin--) {
                 if(costheta <= costheta_upp[ibin-1]) {
                   npairs[ibin]++;
-                  if(need_rpavg) {
+                  if(need_thetaavg) {
                       thetaavg[ibin] += theta;
                   }
                   if(need_weightavg){
@@ -522,8 +522,8 @@ static inline int countpairs_theta_mocks_sse_intrinsics_DOUBLE(const int64_t N0,
 
     for(int i=0;i<nthetabin;i++) {
         src_npairs[i] += npairs[i];
-        if(need_rpavg) {
-            src_rpavg[i] += thetaavg[i];
+        if(need_thetaavg) {
+            src_thetaavg[i] += thetaavg[i];
         }
         if(need_weightavg) {
             src_weightavg[i] += weightavg[i];
@@ -548,7 +548,7 @@ static inline int countpairs_theta_mocks_avx_intrinsics_DOUBLE(const int64_t N0,
                                                                 const DOUBLE min_xdiff, const DOUBLE min_ydiff,
                                                                 const DOUBLE min_zdiff, const DOUBLE closest_icell_xpos,
                                                                 const DOUBLE closest_icell_ypos, const DOUBLE closest_icell_zpos,
-                                                                DOUBLE *src_rpavg, uint64_t *src_npairs,
+                                                                DOUBLE *src_thetaavg, uint64_t *src_npairs,
                                                                 DOUBLE *src_weightavg, const weight_method_t weight_method)
 {
     if(N0 == 0 || N1 == 0) {
@@ -568,11 +568,11 @@ static inline int countpairs_theta_mocks_avx_intrinsics_DOUBLE(const int64_t N0,
                                                     min_xdiff, min_ydiff,
                                                     min_zdiff, closest_icell_xpos,
                                                     closest_icell_ypos, closest_icell_zpos,
-                                                    src_rpavg, src_npairs, src_weightavg, weight_method);
+                                                    src_thetaavg, src_npairs, src_weightavg, weight_method);
     }
 
 
-    const int32_t need_rpavg = src_rpavg != NULL;
+    const int32_t need_thetaavg = src_thetaavg != NULL;
     const int32_t need_weightavg = src_weightavg != NULL;
 
     /* const DOUBLE max_chord_sep = 2.0*SIND(0.5*thetamax); */
@@ -591,7 +591,7 @@ static inline int countpairs_theta_mocks_avx_intrinsics_DOUBLE(const int64_t N0,
         npairs[i] = 0;
         m_costheta_upp[i] = AVX_SET_FLOAT(costheta_upp[i]);
         m_kbin[i] = AVX_SET_FLOAT((DOUBLE) i);
-        if(need_rpavg) {
+        if(need_thetaavg) {
             thetaavg[i] = ZERO;
         }
         if(need_weightavg){
@@ -737,10 +737,10 @@ static inline int countpairs_theta_mocks_avx_intrinsics_DOUBLE(const int64_t N0,
             }
 
             AVX_FLOATS m_thetabin;
-            if(need_rpavg || need_weightavg) {
+            if(need_thetaavg || need_weightavg) {
                 m_thetabin = AVX_SETZERO_FLOAT();
             }
-            if(need_rpavg){
+            if(need_thetaavg){
                 //first do the acos to get the actual angles
                 const AVX_FLOATS m_inv_pi_over_180 = AVX_SET_FLOAT(INV_PI_OVER_180);
                 const AVX_FLOATS m_theta = AVX_ARC_COSINE(m_costheta, order);
@@ -769,7 +769,7 @@ static inline int countpairs_theta_mocks_avx_intrinsics_DOUBLE(const int64_t N0,
               const AVX_FLOATS m1 = AVX_COMPARE_FLOATS(m_costheta,m_costheta_upp[kbin-1],_CMP_LE_OS);
               const AVX_FLOATS m_bin_mask = AVX_BITWISE_AND(m1,m_mask_left);
               const int test = AVX_TEST_COMPARISON(m_bin_mask);
-              if(need_rpavg || need_weightavg) {
+              if(need_thetaavg || need_weightavg) {
                   m_thetabin = AVX_BLEND_FLOATS_WITH_MASK(m_thetabin,m_kbin[kbin], m_bin_mask);
               }
 
@@ -780,14 +780,14 @@ static inline int countpairs_theta_mocks_avx_intrinsics_DOUBLE(const int64_t N0,
               }
           }
 
-          if(need_rpavg || need_weightavg) {
+          if(need_thetaavg || need_weightavg) {
               union_rpbin.m_ibin = AVX_TRUNCATE_FLOAT_TO_INT(m_thetabin);
 #if  __INTEL_COMPILER
 #pragma unroll(AVX_NVEC)
 #endif
               for(int jj=0;jj<AVX_NVEC;jj++) {
                   const int kbin = union_rpbin.ibin[jj];
-                  if(need_rpavg){
+                  if(need_thetaavg){
                       const DOUBLE theta = union_mDperp.Dperp[jj];
                       thetaavg[kbin] += theta;
                   }
@@ -817,7 +817,7 @@ static inline int countpairs_theta_mocks_avx_intrinsics_DOUBLE(const int64_t N0,
               continue;
           }
           DOUBLE theta = ZERO, pairweight = ZERO;
-          if(need_rpavg) {
+          if(need_thetaavg) {
               if(order) {
                   theta =  INV_PI_OVER_180*FAST_ACOS(costheta) ;
               } else {
@@ -839,7 +839,7 @@ static inline int countpairs_theta_mocks_avx_intrinsics_DOUBLE(const int64_t N0,
           for(int ibin=nthetabin-1;ibin>=1;ibin--) {
               if(costheta <= costheta_upp[ibin-1]) {
                   npairs[ibin]++;
-                  if(need_rpavg) {
+                  if(need_thetaavg) {
                       thetaavg[ibin] += theta;
                   }
                   if(need_weightavg){
@@ -853,8 +853,8 @@ static inline int countpairs_theta_mocks_avx_intrinsics_DOUBLE(const int64_t N0,
 
     for(int i=0;i<nthetabin;i++) {
         src_npairs[i] += npairs[i];
-        if(need_rpavg) {
-            src_rpavg[i] += thetaavg[i];
+        if(need_thetaavg) {
+            src_thetaavg[i] += thetaavg[i];
         }
         if(need_weightavg) {
             src_weightavg[i] += weightavg[i];
@@ -879,7 +879,7 @@ static inline int countpairs_theta_mocks_avx512_intrinsics_DOUBLE(const int64_t 
                                                                    const DOUBLE min_xdiff, const DOUBLE min_ydiff,
                                                                    const DOUBLE min_zdiff, const DOUBLE closest_icell_xpos,
                                                                    const DOUBLE closest_icell_ypos, const DOUBLE closest_icell_zpos,
-                                                                   DOUBLE *src_rpavg, uint64_t *src_npairs,
+                                                                   DOUBLE *src_thetaavg, uint64_t *src_npairs,
                                                                    DOUBLE *src_weightavg, const weight_method_t weight_method)
 {
     if(N0 == 0 || N1 == 0) {
@@ -900,11 +900,11 @@ static inline int countpairs_theta_mocks_avx512_intrinsics_DOUBLE(const int64_t 
                                                     min_xdiff, min_ydiff,
                                                     min_zdiff, closest_icell_xpos,
                                                     closest_icell_ypos, closest_icell_zpos,
-                                                    src_rpavg, src_npairs, src_weightavg, weight_method);
+                                                    src_thetaavg, src_npairs, src_weightavg, weight_method);
     }
 #endif
 
-    const int32_t need_rpavg = src_rpavg != NULL;
+    const int32_t need_thetaavg = src_thetaavg != NULL;
     const int32_t need_weightavg = src_weightavg != NULL;
 
     /* const DOUBLE max_chord_sep = 2.0*SIND(0.5*thetamax); */
@@ -917,7 +917,7 @@ static inline int countpairs_theta_mocks_avx512_intrinsics_DOUBLE(const int64_t 
 
     uint64_t npairs[nthetabin];
     DOUBLE thetaavg[nthetabin], weightavg[nthetabin];
-    if(need_rpavg || need_weightavg){
+    if(need_thetaavg || need_weightavg){
         for(int i=0;i<nthetabin;i++) {
             thetaavg[i] = ZERO;
             weightavg[i] = ZERO;
@@ -1070,7 +1070,7 @@ static inline int countpairs_theta_mocks_avx512_intrinsics_DOUBLE(const int64_t 
                 continue;
             }
 
-            if(need_rpavg){
+            if(need_thetaavg){
                 //first do the acos to get the actual angles
                 const AVX512_FLOATS m_inv_pi_over_180 = AVX512_SET_FLOAT(INV_PI_OVER_180);
                 const AVX512_FLOATS m_theta = AVX512_ARC_COSINE(m_costheta, order);
@@ -1100,7 +1100,7 @@ static inline int countpairs_theta_mocks_avx512_intrinsics_DOUBLE(const int64_t 
             for(int kbin=nthetabin-1;kbin>=1;kbin--) {
                 const AVX512_MASK m_bin_mask = AVX512_MASK_COMPARE_FLOATS(m_mask_left, m_costheta,m_costheta_upp[kbin-1],_CMP_LE_OQ);
                 npairs[kbin] += bits_set_in_avx512_mask_DOUBLE[m_bin_mask];
-                if(need_rpavg || need_weightavg) {
+                if(need_thetaavg || need_weightavg) {
                     m_thetabin = AVX512_BLEND_INTS_WITH_MASK(m_bin_mask, m_thetabin, AVX512_SET_INT(kbin));
                 }
                 m_mask_left = AVX512_MASK_BITWISE_AND_NOT(m_bin_mask, m_mask_left);//ANDNOT(X, Y) -> NOT X AND Y
@@ -1109,14 +1109,14 @@ static inline int countpairs_theta_mocks_avx512_intrinsics_DOUBLE(const int64_t 
                 }
             }//backwards loop over the bins
 
-            if(need_rpavg || need_weightavg) {
+            if(need_thetaavg || need_weightavg) {
                 union_rpbin.m_ibin = m_thetabin;
 #if  __INTEL_COMPILER
 #pragma unroll(AVX512_NVEC)
 #endif
                 for(int jj=0;jj<AVX512_NVEC;jj++) {
                     const int kbin = union_rpbin.ibin[jj];
-                    if(need_rpavg) {
+                    if(need_thetaavg) {
                         thetaavg[kbin] += union_mDperp.Dperp[jj];
                     }
                   if(need_weightavg) {
@@ -1129,8 +1129,8 @@ static inline int countpairs_theta_mocks_avx512_intrinsics_DOUBLE(const int64_t 
 
     for(int i=0;i<nthetabin;i++) {
         src_npairs[i] += npairs[i];
-        if(need_rpavg) {
-            src_rpavg[i] += thetaavg[i];
+        if(need_thetaavg) {
+            src_thetaavg[i] += thetaavg[i];
         }
         if(need_weightavg) {
             src_weightavg[i] += weightavg[i];

--- a/theory/DD/countpairs_kernels.c.src
+++ b/theory/DD/countpairs_kernels.c.src
@@ -881,39 +881,16 @@ static inline int countpairs_fallback_DOUBLE(const int64_t N0, DOUBLE *x0, DOUBL
                                              const DOUBLE off_xwrap, const DOUBLE off_ywrap, const DOUBLE off_zwrap,
                                              const DOUBLE min_xdiff, const DOUBLE min_ydiff, const DOUBLE min_zdiff,
                                              const DOUBLE closest_icell_xpos, const DOUBLE closest_icell_ypos, const DOUBLE closest_icell_zpos,
-                                             DOUBLE *src_rpavg, uint64_t *src_npairs,
-                                             DOUBLE *src_weightavg, const weight_method_t weight_method)
+                                             DOUBLE *restrict src_rpavg, uint64_t *restrict src_npairs,
+                                             DOUBLE *restrict src_weightavg, const weight_method_t weight_method)
 {
     /*----------------- FALLBACK CODE --------------------*/
     /* implementation that is guaranteed to compile */
-    const int32_t need_rpavg = src_rpavg != NULL;
-    const int32_t need_weightavg = src_weightavg != NULL;
 
-    uint64_t npairs[nbin];
-    for(int i=0;i<nbin;i++) {
-        npairs[i]=0;
-    }
-    DOUBLE rpavg[nbin], weightavg[nbin];
-    for(int i=0;i<nbin;i++) {
-        if(need_rpavg) {
-            rpavg[i]=0.;
-        }
-        if(need_weightavg){
-            weightavg[i]=0.;
-        }
-    }
-
-    // A copy whose pointers we can advance
-    weight_struct_DOUBLE local_w0 = {.weights={NULL}, .num_weights=0}, local_w1 = {.weights={NULL}, .num_weights=0};
     pair_struct_DOUBLE pair = {.num_weights=0};
     weight_func_t_DOUBLE weight_func = NULL;
-    if(need_weightavg){
-        // Same particle list, new copy of num_weights pointers into that list
-        local_w0 = *weights0;
-        local_w1 = *weights1;
-
-        pair.num_weights = local_w0.num_weights;
-
+    if(src_weightavg != NULL){
+        pair.num_weights = weights0->num_weights;
         weight_func = get_weight_func_by_method_DOUBLE(weight_method);
     }
 
@@ -924,7 +901,7 @@ static inline int countpairs_fallback_DOUBLE(const int64_t N0, DOUBLE *x0, DOUBL
         const DOUBLE ypos = *y0++ + off_ywrap;
         const DOUBLE zpos = *z0++ + off_zwrap;
         for(int w = 0; w < pair.num_weights; w++){
-            pair.weights0[w].d = *local_w0.weights[w]++;
+            pair.weights0[w].d = *(weights0->weights[w] + i);
         }
         DOUBLE max_dz = max_all_dz;
 
@@ -980,45 +957,36 @@ static inline int countpairs_fallback_DOUBLE(const int64_t N0, DOUBLE *x0, DOUBL
         const int64_t nleft = zend - localz1;
         DOUBLE *localx1 = x1 + n_off;
         DOUBLE *localy1 = y1 + n_off;
-        for(int w = 0; w < pair.num_weights; w++){
-            local_w1.weights[w] = weights1->weights[w] + n_off;
-        }
 
         for(int64_t j=0;j<nleft;j++) {
             const DOUBLE dx = *localx1++ - xpos;
             const DOUBLE dy = *localy1++ - ypos;
             const DOUBLE dz = *localz1++ - zpos;
-            for(int w = 0; w < pair.num_weights; w++){
-                pair.weights1[w].d = *local_w1.weights[w]++;
-            }
-
             if(dz >= max_dz) break;
 
             const DOUBLE r2 = dx*dx + dy*dy + dz*dz;
             if(r2 >= sqr_rpmax || r2 < sqr_rpmin) continue;
 
-            if(need_weightavg){
+            DOUBLE pairweight = ZERO;
+            if(src_weightavg != NULL){
+                for(int w = 0; w < pair.num_weights; w++){
+                    pair.weights1[w].d = *(weights1->weights[w] + n_off + j);
+                }
+                
                 pair.dx.d = dx;
                 pair.dy.d = dy;
                 pair.dz.d = dz;
-            }
-
-            DOUBLE r = ZERO, pairweight = ZERO;
-            if(need_rpavg) {
-                r = SQRT(r2);
-            }
-            if(need_weightavg){
                 pairweight = weight_func(&pair);
             }
 
             for(int kbin=nbin-1;kbin>=1;kbin--){
                 if(r2 >= rupp_sqr[kbin-1]) {
-                    npairs[kbin]++;
-                    if(need_rpavg) {
-                        rpavg[kbin] += r;
+                    src_npairs[kbin]++;
+                    if(src_rpavg != NULL) {
+                        src_rpavg[kbin] += SQRT(r2);
                     }
-                    if(need_weightavg){
-                        weightavg[kbin] += pairweight;
+                    if(src_weightavg != NULL){
+                        src_weightavg[kbin] += pairweight;
                     }
                     break;
                 }
@@ -1026,16 +994,6 @@ static inline int countpairs_fallback_DOUBLE(const int64_t N0, DOUBLE *x0, DOUBL
         }
     }
 
-    for(int i=0;i<nbin;i++) {
-        src_npairs[i] += npairs[i];
-        if(need_rpavg) {
-            src_rpavg[i] += rpavg[i];
-        }
-        if(need_weightavg){
-            src_weightavg[i] += weightavg[i];
-        }
-    }
     /*----------------- FALLBACK CODE --------------------*/
-
     return EXIT_SUCCESS;
 }

--- a/theory/DDrppi/countpairs_rp_pi_kernels.c.src
+++ b/theory/DDrppi/countpairs_rp_pi_kernels.c.src
@@ -973,10 +973,10 @@ static inline int countpairs_rp_pi_fallback_DOUBLE(const int64_t N0, DOUBLE *x0,
                                                    const DOUBLE off_xwrap, const DOUBLE off_ywrap, const DOUBLE off_zwrap,
                                                    const DOUBLE min_xdiff, const DOUBLE min_ydiff, const DOUBLE min_zdiff,
                                                    const DOUBLE closest_icell_xpos, const DOUBLE closest_icell_ypos, const DOUBLE closest_icell_zpos,
-                                                   DOUBLE *src_rpavg, uint64_t *src_npairs,
-                                                   DOUBLE *src_weightavg, const weight_method_t weight_method)
+                                                   DOUBLE *restrict src_rpavg, uint64_t * restrict src_npairs,
+                                                   DOUBLE *restrict src_weightavg, const weight_method_t weight_method)
 {
-
+    /*----------------- FALLBACK CODE --------------------*/
     if(N0 == 0 || N1 == 0) {
         return EXIT_SUCCESS;
     }
@@ -985,33 +985,10 @@ static inline int countpairs_rp_pi_fallback_DOUBLE(const int64_t N0, DOUBLE *x0,
         return EXIT_FAILURE;
     }
 
-    /*----------------- FALLBACK CODE --------------------*/
-    const int32_t need_rpavg = src_rpavg != NULL;
-    const int32_t need_weightavg = src_weightavg != NULL;
-    const int64_t totnbins = (npibin+1)*(nbin+1);
-    uint64_t npairs[totnbins];
-    DOUBLE rpavg[totnbins], weightavg[totnbins];
-    for(int i=0;i<totnbins;i++) {
-        npairs[i] = 0;
-        if(need_rpavg) {
-            rpavg[i]=ZERO;
-        }
-        if(need_weightavg){
-            weightavg[i]=ZERO;
-        }
-    }
-
-    // A copy whose pointers we can advance
-    weight_struct_DOUBLE local_w0 = {.weights={NULL}, .num_weights=0}, local_w1 = {.weights={NULL}, .num_weights=0};
     pair_struct_DOUBLE pair = {.num_weights=0};
     weight_func_t_DOUBLE weight_func = NULL;
-    if(need_weightavg){
-        // Same particle list, new copy of num_weights pointers into that list
-        local_w0 = *weights0;
-        local_w1 = *weights1;
-
-        pair.num_weights = local_w0.num_weights;
-
+    if(src_weightavg != NULL){
+        pair.num_weights = weights0->num_weights;
         weight_func = get_weight_func_by_method_DOUBLE(weight_method);
     }
 
@@ -1025,7 +1002,7 @@ static inline int countpairs_rp_pi_fallback_DOUBLE(const int64_t N0, DOUBLE *x0,
         const DOUBLE ypos = *y0++ + off_ywrap;
         const DOUBLE zpos = *z0++ + off_zwrap;
         for(int w = 0; w < pair.num_weights; w++){
-            pair.weights0[w].d = *local_w0.weights[w]++;
+            pair.weights0[w].d = *(weights0->weights[w] + i);
         }
 
 #if 0
@@ -1094,17 +1071,11 @@ static inline int countpairs_rp_pi_fallback_DOUBLE(const int64_t N0, DOUBLE *x0,
         DOUBLE *localz1 = z1;
         DOUBLE *localx1 = x1 + n_off;
         DOUBLE *localy1 = y1 + n_off;
-        for(int w = 0; w < pair.num_weights; w++){
-            local_w1.weights[w] = weights1->weights[w] + n_off;
-        }
 
         for(int64_t j=0;j<nleft;j++) {
             const DOUBLE dx = *localx1++ - xpos;
             const DOUBLE dy = *localy1++ - ypos;
             DOUBLE dz = *localz1++ - zpos;
-            for(int w = 0; w < pair.num_weights; w++){
-                pair.weights1[w].d = *local_w1.weights[w]++;
-            }
 
             if(dz <= -pimax) continue;
             if(dz >= pimax) break;
@@ -1113,18 +1084,21 @@ static inline int countpairs_rp_pi_fallback_DOUBLE(const int64_t N0, DOUBLE *x0,
             const DOUBLE r2 = dx*dx + dy*dy ;
             if(r2 >= sqr_rpmax || r2 < sqr_rpmin) continue;
 
-            if(need_weightavg){
+            DOUBLE pairweight = ZERO;
+            if(src_weightavg != NULL){
+                for(int w = 0; w < pair.num_weights; w++){
+                    pair.weights1[w].d = *(weights1->weights[w] + n_off + j);
+                }
+
                 pair.dx.d = dx;
                 pair.dy.d = dy;
                 pair.dz.d = dz;
+                pairweight = weight_func(&pair);
             }
 
-            DOUBLE r = ZERO, pairweight = ZERO;
-            if(need_rpavg) {
+            DOUBLE r = ZERO;
+            if(src_rpavg != NULL) {
                 r = SQRT(r2);
-            }
-            if(need_weightavg){
-                pairweight = weight_func(&pair);
             }
 
             int pibin = (int) (dz*inv_dpi);
@@ -1132,25 +1106,16 @@ static inline int countpairs_rp_pi_fallback_DOUBLE(const int64_t N0, DOUBLE *x0,
             for(int kbin=nbin-1;kbin>=1;kbin--) {
                 if(r2 >= rupp_sqr[kbin-1]) {
                     const int ibin = kbin*(npibin+1) + pibin;
-                    npairs[ibin]++;
-                    if(need_rpavg) {
-                        rpavg[ibin]+=r;
+                    src_npairs[ibin]++;
+                    if(src_rpavg != NULL) {
+                        src_rpavg[ibin] += r;
                     }
-                    if(need_weightavg){
-                        weightavg[ibin] += pairweight;
+                    if(src_weightavg != NULL){
+                        src_weightavg[ibin] += pairweight;
                     }
                     break;
                 }
             }
-        }
-    }
-    for(int i=0;i<totnbins;i++) {
-        src_npairs[i] += npairs[i];
-        if(need_rpavg) {
-            src_rpavg[i] += rpavg[i];
-        }
-        if(need_weightavg){
-            src_weightavg[i] += weightavg[i];
         }
     }
    /*----------------- FALLBACK CODE --------------------*/

--- a/theory/DDsmu/countpairs_s_mu_kernels.c.src
+++ b/theory/DDsmu/countpairs_s_mu_kernels.c.src
@@ -1027,6 +1027,7 @@ static inline int countpairs_s_mu_fallback_DOUBLE(const int64_t N0, DOUBLE *x0, 
                                                   DOUBLE *src_savg, uint64_t *src_npairs,
                                                   DOUBLE *src_weightavg, const weight_method_t weight_method)
 {
+    /*----------------- FALLBACK CODE --------------------*/
 
     (void) fast_divide_and_NR_steps;
     if(N0 == 0 || N1 == 0) {
@@ -1037,33 +1038,10 @@ static inline int countpairs_s_mu_fallback_DOUBLE(const int64_t N0, DOUBLE *x0, 
         return EXIT_FAILURE;
     }
 
-    /*----------------- FALLBACK CODE --------------------*/
-    const int32_t need_savg = src_savg != NULL;
-    const int32_t need_weightavg = src_weightavg != NULL;
-    const int64_t totnbins = (nmu_bins+1)*(nsbin+1);
-    uint64_t npairs[totnbins];
-    DOUBLE savg[totnbins], weightavg[totnbins];
-    for(int i=0;i<totnbins;i++) {
-        npairs[i] = 0;
-        if(need_savg) {
-            savg[i]=ZERO;
-        }
-        if(need_weightavg){
-            weightavg[i]=ZERO;
-        }
-    }
-
-    // A copy whose pointers we can advance
-    weight_struct_DOUBLE local_w0 = {.weights={NULL}, .num_weights=0}, local_w1 = {.weights={NULL}, .num_weights=0};
     pair_struct_DOUBLE pair = {.num_weights=0};
     weight_func_t_DOUBLE weight_func = NULL;
-    if(need_weightavg){
-        // Same particle list, new copy of num_weights pointers into that list
-        local_w0 = *weights0;
-        local_w1 = *weights1;
-
-        pair.num_weights = local_w0.num_weights;
-
+    if(src_weightavg != NULL){
+        pair.num_weights = weights0->num_weights;
         weight_func = get_weight_func_by_method_DOUBLE(weight_method);
     }
 
@@ -1080,7 +1058,7 @@ static inline int countpairs_s_mu_fallback_DOUBLE(const int64_t N0, DOUBLE *x0, 
         const DOUBLE ypos = *y0++ + off_ywrap;
         const DOUBLE zpos = *z0++ + off_zwrap;
         for(int w = 0; w < pair.num_weights; w++){
-            pair.weights0[w].d = *local_w0.weights[w]++;
+            pair.weights0[w].d = *(weights0->weights[w] + i);
         }
         DOUBLE max_dz = max_all_dz;
 
@@ -1159,17 +1137,11 @@ static inline int countpairs_s_mu_fallback_DOUBLE(const int64_t N0, DOUBLE *x0, 
         const int64_t nleft = N1 - n_off;
         DOUBLE *localx1 = x1 + n_off;
         DOUBLE *localy1 = y1 + n_off;
-        for(int w = 0; w < pair.num_weights; w++){
-            local_w1.weights[w] = weights1->weights[w] + n_off;
-        }
 
         for(int64_t j=0;j<nleft;j++) {
             const DOUBLE dx = *localx1++ - xpos;
             const DOUBLE dy = *localy1++ - ypos;
             const DOUBLE dz = *localz1++ - zpos;//the ordering is important. localz1 - zpos ensures dz is in increasing order for future iterations
-            for(int w = 0; w < pair.num_weights; w++){
-                pair.weights1[w].d = *local_w1.weights[w]++;
-            }
             if(dz >= max_dz) break;
 
             const DOUBLE sqr_dx_dy = dx*dx + dy*dy;
@@ -1181,11 +1153,14 @@ static inline int countpairs_s_mu_fallback_DOUBLE(const int64_t N0, DOUBLE *x0, 
 
             const DOUBLE mu = SQRT(sqr_dz/s2);
             DOUBLE s = ZERO, pairweight = ZERO;
-            if(need_savg) {
+            if(src_savg != NULL) {
                 s = SQRT(s2);
             }
 
-            if(need_weightavg){
+            if(src_weightavg != NULL){
+                for(int w = 0; w < pair.num_weights; w++){
+                    pair.weights1[w].d = *(weights1->weights[w] + n_off + j);
+                }
                 pair.dx.d = dx;
                 pair.dy.d = dy;
                 pair.dz.d = dz;
@@ -1197,27 +1172,19 @@ static inline int countpairs_s_mu_fallback_DOUBLE(const int64_t N0, DOUBLE *x0, 
             for(int kbin=nsbin-1;kbin>=1;kbin--) {
                 if(s2 >= supp_sqr[kbin-1]) {
                     const int ibin = kbin*(nmu_bins+1) + mu_bin;
-                    npairs[ibin]++;
-                    if(need_savg) {
-                        savg[ibin] += s;
+                    src_npairs[ibin]++;
+                    if(src_savg != NULL) {
+                        src_savg[ibin] += s;
                     }
-                    if(need_weightavg){
-                        weightavg[ibin] += pairweight;
+                    if(src_weightavg != NULL){
+                        src_weightavg[ibin] += pairweight;
                     }
                     break;
                 }
             }
         }
     }
-    for(int i=0;i<totnbins;i++) {
-        src_npairs[i] += npairs[i];
-        if(need_savg) {
-            src_savg[i] += savg[i];
-        }
-        if(need_weightavg){
-            src_weightavg[i] += weightavg[i];
-        }
-    }
-   /*----------------- FALLBACK CODE --------------------*/
+
+    /*----------------- FALLBACK CODE --------------------*/
     return EXIT_SUCCESS;
 }

--- a/theory/wp/wp_kernels.c.src
+++ b/theory/wp/wp_kernels.c.src
@@ -1356,8 +1356,8 @@ static inline int wp_fallback_DOUBLE(DOUBLE *x0, DOUBLE *y0, DOUBLE *z0, const w
                                      const DOUBLE off_xwrap, const DOUBLE off_ywrap, const DOUBLE off_zwrap,
                                      const DOUBLE min_xdiff, const DOUBLE min_ydiff, const DOUBLE min_zdiff, 
                                      const DOUBLE closest_icell_xpos, const DOUBLE closest_icell_ypos, const DOUBLE closest_icell_zpos,
-                                     DOUBLE *src_rpavg, uint64_t *src_npairs,
-                                     DOUBLE *src_weightavg, const weight_method_t weight_method)
+                                     DOUBLE *restrict src_rpavg, uint64_t *restrict src_npairs,
+                                     DOUBLE *restrict src_weightavg, const weight_method_t weight_method)
 {
 #ifdef COUNT_VECTORIZED
     struct timespec tcell_start;
@@ -1369,29 +1369,21 @@ static inline int wp_fallback_DOUBLE(DOUBLE *x0, DOUBLE *y0, DOUBLE *z0, const w
     /*----------------- FALLBACK CODE --------------------*/
     uint64_t npairs[nbin];
     DOUBLE rpavg[nbin], weightavg[nbin];
-    const int32_t need_rpavg = src_rpavg != NULL;
-    const int32_t need_weightavg = src_weightavg != NULL;
     for(int i=0;i<nbin;i++) {
         npairs[i]=0;
-        if(need_rpavg) {
+        if(src_rpavg != NULL) {
             rpavg[i]=0.0;
         }
-        if(need_weightavg){
+        if(src_weightavg != NULL){
             weightavg[i]=0.;
         }
     }
   
     // A copy whose pointers we can advance
-    weight_struct_DOUBLE local_w0 = {.weights={NULL}, .num_weights=0}, local_w1 = {.weights={NULL}, .num_weights=0};
     pair_struct_DOUBLE pair = {.num_weights=0};
     weight_func_t_DOUBLE weight_func = NULL;
-    if(need_weightavg){
-        // Same particle list, new copy of num_weights pointers into that list
-        local_w0 = *weights0;
-        local_w1 = *weights1;
-        
-        pair.num_weights = local_w0.num_weights;
-        
+    if(src_weightavg != NULL){
+        pair.num_weights = weights0->num_weights;
         weight_func = get_weight_func_by_method_DOUBLE(weight_method);
     }
     
@@ -1402,7 +1394,7 @@ static inline int wp_fallback_DOUBLE(DOUBLE *x0, DOUBLE *y0, DOUBLE *z0, const w
         const DOUBLE ypos = *y0++ + off_ywrap;
         const DOUBLE zpos = *z0++ + off_zwrap;
         for(int w = 0; w < pair.num_weights; w++){
-            pair.weights0[w].d = *local_w0.weights[w]++;
+            pair.weights0[w].d = *(weights0->weights[w] + i);
         }
         
 
@@ -1472,9 +1464,6 @@ static inline int wp_fallback_DOUBLE(DOUBLE *x0, DOUBLE *y0, DOUBLE *z0, const w
         DOUBLE *localz1 = z1;
         DOUBLE *localx1 = x1 + n_off;
         DOUBLE *localy1 = y1 + n_off;
-        for(int w = 0; w < pair.num_weights; w++){
-            local_w1.weights[w] = weights1->weights[w] + n_off;
-        }
         
         for(int64_t j=0;j<nleft;j++) {
 #ifdef COUNT_VECTORIZED
@@ -1483,37 +1472,37 @@ static inline int wp_fallback_DOUBLE(DOUBLE *x0, DOUBLE *y0, DOUBLE *z0, const w
             const DOUBLE dx = *localx1++ - xpos;
             const DOUBLE dy = *localy1++ - ypos;
             const DOUBLE dz = *localz1++ - zpos;
-            for(int w = 0; w < pair.num_weights; w++){
-                pair.weights1[w].d = *local_w1.weights[w]++;
-            }
 
             if(dz <= -pimax) continue;
             if(dz >= pimax) break;
             
             const DOUBLE r2 = dx*dx + dy*dy;
             if(r2 >= sqr_rpmax || r2 < sqr_rpmin) continue;
-            
-            if(need_weightavg){
+
+            DOUBLE pairweight = ZERO;
+            if(src_weightavg != NULL){
+                for(int w = 0; w < pair.num_weights; w++){
+                    pair.weights1[w].d = *(weights1->weights[w] + n_off + j);
+                }
+
                 pair.dx.d = dx;
                 pair.dy.d = dy;
                 pair.dz.d = dz;
+                pairweight = weight_func(&pair);
             }
-            
-            const DOUBLE r = need_rpavg ? SQRT(r2):ZERO;
-            const DOUBLE pairweight = need_weightavg ? weight_func(&pair) : ZERO;
-            
+            const DOUBLE r = (src_rpavg == NULL) ? ZERO:SQRT(r2);
             for(int kbin=nbin-1;kbin>=1;kbin--){
                 if(r2 >= rupp_sqr[kbin-1]) {
                     npairs[kbin]++;
-                    if(need_rpavg) {
+                    if(src_rpavg != NULL) {
                         rpavg[kbin] += r;
                     }
-                    if(need_weightavg){
+                    if(src_weightavg != NULL) {
                         weightavg[kbin] += pairweight;
                     }
                     break;
                 }
-            }//searching for kbin loop                                                               
+            }//searching for kbin loop
         }
     }
 
@@ -1525,10 +1514,10 @@ static inline int wp_fallback_DOUBLE(DOUBLE *x0, DOUBLE *y0, DOUBLE *z0, const w
         npairs_found += npairs[i];
 #endif  
         src_npairs[i] += npairs[i];
-        if(need_rpavg) {
+        if(src_rpavg != NULL) {
             src_rpavg[i] += rpavg[i];
         }
-        if(need_weightavg){
+        if(src_weightavg != NULL){
             src_weightavg[i] += weightavg[i];
         }
     }

--- a/theory/xi/xi_kernels.c.src
+++ b/theory/xi/xi_kernels.c.src
@@ -854,37 +854,14 @@ static inline int xi_fallback_DOUBLE(DOUBLE *x0, DOUBLE *y0, DOUBLE *z0, const w
                                      const DOUBLE off_xwrap, const DOUBLE off_ywrap, const DOUBLE off_zwrap,
                                      const DOUBLE min_xdiff, const DOUBLE min_ydiff, const DOUBLE min_zdiff,
                                      const DOUBLE closest_icell_xpos, const DOUBLE closest_icell_ypos, const DOUBLE closest_icell_zpos,
-                                     DOUBLE *src_ravg, uint64_t *src_npairs,
-                                     DOUBLE *src_weightavg, const weight_method_t weight_method)
+                                     DOUBLE *restrict src_ravg, uint64_t *restrict src_npairs,
+                                     DOUBLE *restrict src_weightavg, const weight_method_t weight_method)
 {
     /*----------------- FALLBACK CODE --------------------*/
-    uint64_t npairs[nbin];
-    for(int i=0;i<nbin;i++) {
-        npairs[i]=0;
-    }
-
-    const int32_t need_ravg = src_ravg != NULL;
-    const int32_t need_weightavg = src_weightavg != NULL;
-    DOUBLE ravg[nbin], weightavg[nbin];
-    for(int i=0;i<nbin;i++) {
-        if(need_ravg) {
-            ravg[i]=0.;
-        }
-        if(need_weightavg){
-            weightavg[i]=0.;
-        }
-    }
-
-    // A copy whose pointers we can advance
-    weight_struct_DOUBLE local_w0 = {.weights={NULL}, .num_weights=0}, local_w1 = {.weights={NULL}, .num_weights=0};
     pair_struct_DOUBLE pair = {.num_weights=0};
     weight_func_t_DOUBLE weight_func = NULL;
-    if(need_weightavg){
-      // Same particle list, new copy of num_weights pointers into that list
-      local_w0 = *weights0;
-      local_w1 = *weights1;
-
-      pair.num_weights = local_w0.num_weights;
+    if(src_weightavg != NULL){
+      pair.num_weights = weights0->num_weights;
       weight_func = get_weight_func_by_method_DOUBLE(weight_method);
     }
 
@@ -895,7 +872,7 @@ static inline int xi_fallback_DOUBLE(DOUBLE *x0, DOUBLE *y0, DOUBLE *z0, const w
         const DOUBLE ypos = *y0++ + off_ywrap;
         const DOUBLE zpos = *z0++ + off_zwrap;
         for(int w = 0; w < pair.num_weights; w++){
-            pair.weights0[w].d = *local_w0.weights[w]++;
+            pair.weights0[w].d = *(weights0->weights[w] + i);
         }
         DOUBLE max_dz = max_all_dz;
 
@@ -952,44 +929,37 @@ static inline int xi_fallback_DOUBLE(DOUBLE *x0, DOUBLE *y0, DOUBLE *z0, const w
         const int64_t nleft = zend - localz1;
         DOUBLE *localx1 = x1 + n_off;
         DOUBLE *localy1 = y1 + n_off;
-        for(int w = 0; w < pair.num_weights; w++){
-            local_w1.weights[w] = weights1->weights[w] + n_off;
-        }
 
         for(int64_t j=0;j<nleft;j++) {
             const DOUBLE dx = *localx1++ - xpos;
             const DOUBLE dy = *localy1++ - ypos;
             const DOUBLE dz = *localz1++ - zpos;
-            for(int w = 0; w < pair.num_weights; w++){
-                pair.weights1[w].d = *local_w1.weights[w]++;
-            }
             if(dz >= max_dz) break;
 
             const DOUBLE r2 = dx*dx + dy*dy + dz*dz;
-
             if(r2 >= sqr_rmax || r2 < sqr_rmin) continue;
-            if(need_weightavg){
+
+            DOUBLE pairweight = ZERO;            
+            if(src_weightavg != NULL){
+                for(int w = 0; w < pair.num_weights; w++){
+                    pair.weights1[w].d = *(weights1->weights[w] + n_off + j);
+                }
+
                 pair.dx.d = dx;
                 pair.dy.d = dy;
                 pair.dz.d = dz;
-            }
-
-            DOUBLE r = ZERO, pairweight = ZERO;
-            if(need_ravg) {
-                r = SQRT(r2);
-            }
-            if(need_weightavg){
                 pairweight = weight_func(&pair);
             }
 
+            const DOUBLE r = (src_ravg == NULL) ? ZERO:SQRT(r2);
             for(int kbin=nbin-1;kbin>=1;kbin--){
                 if(r2 >= rupp_sqr[kbin-1]) {
-                    npairs[kbin]++;
-                    if(need_ravg) {
-                        ravg[kbin] += r;
+                    src_npairs[kbin]++;
+                    if(src_ravg != NULL) {
+                        src_ravg[kbin] += r;
                     }
-                    if(need_weightavg){
-                        weightavg[kbin] += pairweight;
+                    if(src_weightavg != NULL){
+                        src_weightavg[kbin] += pairweight;
                     }
                     break;
                 }
@@ -997,15 +967,6 @@ static inline int xi_fallback_DOUBLE(DOUBLE *x0, DOUBLE *y0, DOUBLE *z0, const w
         }
     }
 
-    for(int i=0;i<nbin;i++) {
-        src_npairs[i] += npairs[i];
-        if(need_ravg) {
-            src_ravg[i] += ravg[i];
-        }
-        if(need_weightavg){
-            src_weightavg[i] += weightavg[i];
-        }
-    }
     /*----------------- FALLBACK CODE --------------------*/
     return EXIT_SUCCESS;
 }


### PR DESCRIPTION
Reduced the amount of code in the fallback kernels. At least on my M2 laptop, it runs faster - slightly faster (5-10%) for DD-type (i.e. small number-density) and significantly (~20-25%) faster for RR-type calculations